### PR TITLE
fix(xunit.microservice): :bug: fix "Unable to load one or more of the…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,8 @@
         "net.rabbitmq",
         "net.serializers",
         "net.generator",
-        "net.observability"
+        "net.observability",
+        "xunit.microservice"
     ],
     "sonarlint.connectedMode.project": {
         "connectionId": "codedesignplus",

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core/CodeDesignPlus.Net.Core.csproj
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core/CodeDesignPlus.Net.Core.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>  
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>{E2CEBBAF-6DF7-41E9-815D-9AD4CF90C844}</ProjectGuid>
 		<PublishAot>false</PublishAot>
     <TargetFramework>net8.0</TargetFramework>

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/AggregateAttribute.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/AggregateAttribute.cs
@@ -8,6 +8,7 @@ namespace CodeDesignPlus.Net.xUnit.Microservice.Attributes;
 /// </remarks>
 /// <typeparam name="TAssemblyScan">The type of the assembly to scan for aggregates.</typeparam>
 /// <param name="useCreateMethod">Indicates whether to use the static Create method or the constructor to create instances of aggregates.</param>
+[AttributeUsage(AttributeTargets.Method)]
 public class AggregateAttribute<TAssemblyScan>(bool useCreateMethod) : DataAttribute where TAssemblyScan: IErrorCodes
 {
     /// <summary>
@@ -19,7 +20,7 @@ public class AggregateAttribute<TAssemblyScan>(bool useCreateMethod) : DataAttri
     {
         var aggregates = typeof(TAssemblyScan).Assembly
             .GetTypes()
-            .Where(x => !x.FullName.StartsWith("Castle"))
+            .Where(x => !x.FullName.StartsWith("Castle") || !x.FullName.Contains("DynamicProxyGenAssembly"))
             .Where(x => x.IsClass && !x.IsAbstract && x.IsSubclassOf(typeof(AggregateRoot)))
             .ToList();
 

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/CommandAttribute.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/CommandAttribute.cs
@@ -4,6 +4,7 @@ namespace CodeDesignPlus.Net.xUnit.Microservice.Attributes;
 /// A custom attribute for providing data to test methods that validate commands.
 /// </summary>
 /// <typeparam name="TAssemblyScan">The type of the assembly to scan for commands.</typeparam>
+[AttributeUsage(AttributeTargets.Method)]
 public class CommandAttribute<TAssemblyScan> : DataAttribute
 {
     /// <summary>
@@ -13,9 +14,9 @@ public class CommandAttribute<TAssemblyScan> : DataAttribute
     /// <returns>An enumerable of object arrays representing the data for the test method.</returns>
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        var commands = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(x => x.GetTypes())
-            .Where(x => !x.FullName.StartsWith("Castle"))
+        var commands = typeof(TAssemblyScan).Assembly
+            .GetTypes()
+            .Where(x => !x.FullName.StartsWith("Castle") || !x.FullName.Contains("DynamicProxyGenAssembly"))
             .Where(x => typeof(IRequest).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract)
             .ToList();
 

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/DataTransferObjectAttribute.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/DataTransferObjectAttribute.cs
@@ -4,6 +4,7 @@ namespace CodeDesignPlus.Net.xUnit.Microservice.Attributes;
 /// A custom attribute for providing data to test methods that validate data transfer objects (DTOs).
 /// </summary>
 /// <typeparam name="TAssemblyScan">The type of the assembly to scan for DTOs.</typeparam>
+[AttributeUsage(AttributeTargets.Method)]
 public class DataTransferObjectAttribute<TAssemblyScan> : DataAttribute
 {
     /// <summary>
@@ -13,9 +14,9 @@ public class DataTransferObjectAttribute<TAssemblyScan> : DataAttribute
     /// <returns>An enumerable of object arrays representing the data for the test method.</returns>
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        var dtos = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(x => x.GetTypes())
-            .Where(x => !x.FullName.StartsWith("Castle"))
+        var dtos = typeof(TAssemblyScan).Assembly
+            .GetTypes()
+            .Where(x => !x.FullName.StartsWith("Castle") || !x.FullName.Contains("DynamicProxyGenAssembly"))
             .Where(x => typeof(IDtoBase).IsAssignableFrom(x) && x.IsClass && !x.IsAbstract)
             .ToList();
 

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/DomainEventAttribute.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/DomainEventAttribute.cs
@@ -5,6 +5,7 @@ namespace CodeDesignPlus.Net.xUnit.Microservice.Attributes;
 /// </summary>
 /// <typeparam name="TAssemblyScan">The type of the assembly to scan for domain events.</typeparam>
 /// <param name="useCreateMethod">Indicates whether to use the static Create method or the constructor to create instances of domain events.</param>
+[AttributeUsage(AttributeTargets.Method)]
 public class DomainEventAttribute<TAssemblyScan>(bool useCreateMethod) : DataAttribute
 {
     /// <summary>
@@ -14,9 +15,9 @@ public class DomainEventAttribute<TAssemblyScan>(bool useCreateMethod) : DataAtt
     /// <returns>An enumerable of object arrays representing the data for the test method.</returns>
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        var domainEvents = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(x => x.GetTypes())
-            .Where(x => !x.FullName.StartsWith("Castle"))
+        var domainEvents = typeof(TAssemblyScan).Assembly
+            .GetTypes()
+            .Where(x => !x.FullName.StartsWith("Castle") || !x.FullName.Contains("DynamicProxyGenAssembly"))
             .Where(x => typeof(IDomainEvent).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract)
             .ToList();
 

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/EntityAttribute.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/EntityAttribute.cs
@@ -4,6 +4,7 @@ namespace CodeDesignPlus.Net.xUnit.Microservice.Attributes;
 /// A custom attribute for providing data to test methods that validate entities.
 /// </summary>
 /// <typeparam name="TAssemblyScan">The type of the assembly to scan for entities.</typeparam>
+[AttributeUsage(AttributeTargets.Method)]
 public class EntityAttribute<TAssemblyScan> : DataAttribute
 {
     /// <summary>
@@ -13,9 +14,9 @@ public class EntityAttribute<TAssemblyScan> : DataAttribute
     /// <returns>An enumerable of object arrays representing the data for the test method.</returns>
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        var entities = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(x => x.GetTypes())
-            .Where(x => !x.FullName.StartsWith("Castle"))
+        var entities = typeof(TAssemblyScan).Assembly
+            .GetTypes()
+            .Where(x => !x.FullName.StartsWith("Castle") || !x.FullName.Contains("DynamicProxyGenAssembly"))
             .Where(x => typeof(IEntityBase).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract && !x.IsSubclassOf(typeof(AggregateRoot)))
             .ToList();
 

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/ErrorsAttribute.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/ErrorsAttribute.cs
@@ -4,6 +4,7 @@ namespace CodeDesignPlus.Net.xUnit.Microservice.Attributes;
 /// A custom attribute for providing data to test methods that validate error formats.
 /// </summary>
 /// <typeparam name="TAssemblyScan">The type of the assembly to scan for errors.</typeparam>
+[AttributeUsage(AttributeTargets.Method)]
 public class ErrorsAttribute<TAssemblyScan> : DataAttribute
 {
     /// <summary>
@@ -13,9 +14,9 @@ public class ErrorsAttribute<TAssemblyScan> : DataAttribute
     /// <returns>An enumerable of object arrays representing the data for the test method.</returns>
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        var errorClasses = AppDomain.CurrentDomain.GetAssemblies()
-           .SelectMany(x => x.GetTypes())
-           .Where(x => !x.FullName.StartsWith("Castle"))
+        var errorClasses = typeof(TAssemblyScan).Assembly
+            .GetTypes()
+           .Where(x => !x.FullName.StartsWith("Castle") || !x.FullName.Contains("DynamicProxyGenAssembly"))
            .Where(x => typeof(IErrorCodes).IsAssignableFrom(x) && x.IsClass && !x.IsAbstract)
            .ToList();
 

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/QueryAttribute.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/QueryAttribute.cs
@@ -4,6 +4,7 @@ namespace CodeDesignPlus.Net.xUnit.Microservice.Attributes;
 /// A custom attribute for providing data to test methods that validate queries.
 /// </summary>
 /// <typeparam name="TAssemblyScan">The type of the assembly to scan for queries.</typeparam>
+[AttributeUsage(AttributeTargets.Method)]
 public class QueryAttribute<TAssemblyScan> : DataAttribute
 {
     /// <summary>
@@ -13,10 +14,10 @@ public class QueryAttribute<TAssemblyScan> : DataAttribute
     /// <returns>An enumerable of object arrays representing the data for the test method.</returns>
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        var queries = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(x => x.GetTypes())
-            .Where(x => !x.FullName.StartsWith("Castle"))
-            .Where(x => x.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>)) && !x.IsInterface && !x.IsAbstract)
+        var queries = typeof(TAssemblyScan).Assembly
+            .GetTypes()
+            .Where(x => !x.FullName.StartsWith("Castle") || !x.FullName.Contains("DynamicProxyGenAssembly"))
+            .Where(x => x.GetInterfaces().ToList().Exists(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>)) && !x.IsInterface && !x.IsAbstract)
             .ToList();
 
         foreach (var query in queries)

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/StartupAttribute.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Attributes/StartupAttribute.cs
@@ -4,6 +4,7 @@ namespace CodeDesignPlus.Net.xUnit.Microservice.Attributes;
 /// A custom attribute for providing data to test methods that validate startup services.
 /// </summary>
 /// <typeparam name="TAssemblyScan">The type of the assembly to scan for startup services.</typeparam>
+[AttributeUsage(AttributeTargets.Method)]
 public class StartupAttribute<TAssemblyScan> : DataAttribute
 {
     /// <summary>
@@ -16,9 +17,9 @@ public class StartupAttribute<TAssemblyScan> : DataAttribute
         var services = new ServiceCollection();
         var configuration = new ConfigurationBuilder().Build();
 
-        var startups = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(x => x.GetTypes())
-            .Where(x => !x.FullName.StartsWith("Castle"))
+        var startups = typeof(TAssemblyScan).Assembly
+            .GetTypes()
+            .Where(x => !x.FullName.StartsWith("Castle") || !x.FullName.Contains("DynamicProxyGenAssembly"))
             .Where(x => typeof(IStartupServices).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract)
             .Select(x => (IStartupServices)Activator.CreateInstance(x))
             .ToList();


### PR DESCRIPTION
# **Description**

This pull request addresses an issue where a test file failed due to a `System.Reflection.ReflectionTypeLoadException`. The error message indicated that the type `Castle.Proxies.ILogger`1Proxy` could not be loaded from the assembly `DynamicProxyGenAssembly2`. The issue was traced to the `QueryAttribute` class in the `CodeDesignPlus.Net.xUnit.Microservice` project. Additionally, all attributes that follow the same process have been adjusted.

Fixes # (issue)

## **Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# **How Has This Been Tested?**

The following tests were run to verify the changes:

- [x] Test A: Verified that the `QueryAttribute` class can now load all required types without throwing a `ReflectionTypeLoadException`.
- [x] Test B: Ensured that all unit tests in the `CodeDesignPlus.Net.xUnit.Microservice` project pass successfully.

![image](https://github.com/user-attachments/assets/688db43e-e22c-4c96-8367-593951dbcd6b)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules