### PR TITLE
ci: :green_heart: add conditional main ~1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,17 +94,36 @@ jobs:
       - name: Build Packages
         run: pnpm run affected:build
 
-      - name: Run SonarQube
-        if: env.IS_RELEASE == 'true' || env.IS_RC == 'true' || env.IS_BETA == 'true'
+      - name: Run SonarQube Main
+        if: env.IS_RELEASE == 'true'
         run: pnpm run affected:sonarqube
 
+      - name: .Net Pack Main
+        if: env.IS_RELEASE == 'true'
+        run: npx nx affected --skip-nx-cache --target pack --head=HEAD --base=remotes/origin/main~1 --args="--version=${{ steps.git-semver.outputs.new-version }}"
+
+      - name: .Net Push GitHub Package Main
+        if: env.IS_RELEASE == 'true'
+        run: npx nx affected --skip-nx-cache --target push --head=HEAD --base=remotes/origin/main~1 --args="--token=${{secrets.GITHUB_TOKEN}} --source=https://nuget.pkg.github.com/codedesignplus/index.json"
+        
+      - name: .Net Push NuGet Package Main
+        if: env.IS_RELEASE == 'true'
+        run: npx nx affected --skip-nx-cache --target push --head=HEAD --base=remotes/origin/main~1 --args="--source=https://api.nuget.org/v3/index.json --token=${{env.NUGET_TOKEN}}"
+        
+      - name: Run SonarQube
+        if: env.IS_RC == 'true' || env.IS_BETA == 'true'
+        run: pnpm run affected:sonarqube
+        
       - name: .Net Pack
+        if: env.IS_RC == 'true' || env.IS_BETA == 'true'
         run: npx nx affected --skip-nx-cache --target pack --head=HEAD --base=remotes/origin/main --args="--version=${{ steps.git-semver.outputs.new-version }}"
 
       - name: .Net Push GitHub Package
+        if: env.IS_RC == 'true' || env.IS_BETA == 'true'
         run: npx nx affected --skip-nx-cache --target push --head=HEAD --base=remotes/origin/main --args="--token=${{secrets.GITHUB_TOKEN}} --source=https://nuget.pkg.github.com/codedesignplus/index.json"
         
       - name: .Net Push NuGet Package
+        if: env.IS_RC == 'true' || env.IS_BETA == 'true'
         run: npx nx affected --skip-nx-cache --target push --head=HEAD --base=remotes/origin/main --args="--source=https://api.nuget.org/v3/index.json --token=${{env.NUGET_TOKEN}}"
 
       - name: Push tag


### PR DESCRIPTION
This pull request includes updates to the CI workflow configuration in `.github/workflows/ci.yaml` to better handle different release conditions. The most important changes involve adding new steps for the main release process and adjusting conditions for existing steps.

### Updates to CI Workflow Configuration:

* Added new steps for the main release process, including running SonarQube, packaging, and pushing .Net packages to GitHub and NuGet. These steps are conditioned to run only if `env.IS_RELEASE` is set to `'true'`. (`.github/workflows/ci.yaml`)

* Adjusted the conditions for existing SonarQube, .Net Pack, and .Net Push steps to run only if `env.IS_RC` or `env.IS_BETA` is set to `'true'`. (`.github/workflows/ci.yaml`)