### PR TITLE
feat(net.vault): :construction: add auth token vault

### DIFF
--- a/packages/CodeDesignPlus.Net.Vault/src/CodeDesignPlus.Net.Vault.Abstractions/Options/TypeAuth.cs
+++ b/packages/CodeDesignPlus.Net.Vault/src/CodeDesignPlus.Net.Vault.Abstractions/Options/TypeAuth.cs
@@ -1,0 +1,24 @@
+namespace CodeDesignPlus.Net.Vault.Abstractions.Options;
+
+/// <summary>
+/// Type of authentication to use in the Vault
+/// </summary>
+public enum TypeAuth
+{
+    /// <summary>
+    /// None authentication
+    /// </summary>
+    None,
+    /// <summary>
+    /// Token authentication
+    /// </summary>
+    Token,
+    /// <summary>
+    /// AppRole authentication
+    /// </summary>
+    AppRole,
+    /// <summary>
+    /// Kubernetes authentication
+    /// </summary>
+    Kubernetes
+}

--- a/packages/CodeDesignPlus.Net.Vault/src/CodeDesignPlus.Net.Vault.Abstractions/Options/VaultOptions.cs
+++ b/packages/CodeDesignPlus.Net.Vault/src/CodeDesignPlus.Net.Vault.Abstractions/Options/VaultOptions.cs
@@ -12,6 +12,31 @@ public class VaultOptions : IValidatableObject
     /// </summary>
     public static readonly string Section = "Vault";
     /// <summary>
+    /// Gets the type of authentication to use in the Vault
+    /// </summary>
+    public TypeAuth TypeAuth
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(this.Token))
+                return TypeAuth.Token;
+            else if (!string.IsNullOrEmpty(this.RoleId) && !string.IsNullOrEmpty(this.SecretId))
+                return TypeAuth.AppRole;
+            else if (this.Kubernetes != null && this.Kubernetes.Enable)
+                return TypeAuth.Kubernetes;
+
+            return TypeAuth.None;
+        }
+    }
+    /// <summary>
+    /// Gets or sets the enable of the Vault server
+    /// </summary>
+    public bool Enable { get; set; }
+    /// <summary>
+    /// Gets or sets the token of the Vault server
+    /// </summary>
+    public string Token { get; set; }
+    /// <summary>
     /// Gets or sets the address of the Vault server
     /// </summary>
     [Required]
@@ -69,10 +94,8 @@ public class VaultOptions : IValidatableObject
     {
         var results = new List<ValidationResult>();
 
-        if (string.IsNullOrEmpty(this.RoleId) && string.IsNullOrEmpty(this.SecretId) && this.Kubernetes != null && !this.Kubernetes.Enable)
-        {
-            results.Add(new ValidationResult("The RoleId and SecretId is required."));
-        }
+        if (this.TypeAuth == TypeAuth.None)
+            results.Add(new ValidationResult("The TypeAuth is required."));
 
         if (this.Mongo != null && this.Mongo.Enable)
         {

--- a/packages/CodeDesignPlus.Net.Vault/src/CodeDesignPlus.Net.Vault/Extensions/VaultExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Vault/src/CodeDesignPlus.Net.Vault/Extensions/VaultExtensions.cs
@@ -42,19 +42,18 @@ public static class VaultExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add configuration to.</param>
     /// <param name="options">An action to configure the <see cref="VaultOptions"/>.</param>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="builder"/> or <paramref name="options"/> is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="builder"/> is null.</exception>
     /// <exception cref="VaultException">Thrown if the Vault configuration section does not exist.</exception>
     /// <returns>The updated <see cref="IConfigurationBuilder"/>.</returns>
-    public static IConfigurationBuilder AddVault(this IConfigurationBuilder builder, Action<VaultOptions> options)
+    public static IConfigurationBuilder AddVault(this IConfigurationBuilder builder, Action<VaultOptions> options = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(options);
 
         var configuration = builder.Build();
 
         var vaultOptions = configuration.GetSection(VaultOptions.Section).Get<VaultOptions>();
 
-        options.Invoke(vaultOptions);
+        options?.Invoke(vaultOptions);
 
         var source = new VaultConfigurationSource(vaultOptions);
 

--- a/packages/CodeDesignPlus.Net.Vault/tests/CodeDesignPlus.Net.Vault.Test/Options/VaultOptionsTest.cs
+++ b/packages/CodeDesignPlus.Net.Vault/tests/CodeDesignPlus.Net.Vault.Test/Options/VaultOptionsTest.cs
@@ -55,12 +55,12 @@ public class VaultOptionsTest
         // Assert
         Assert.NotEmpty(results);
         Assert.Contains(results, x => x.ErrorMessage == "The Address field is required.");
-        Assert.Contains(results, x => x.ErrorMessage == "The RoleId and SecretId is required.");
         Assert.Contains(results, x => x.ErrorMessage == "The AppName field is required.");
         Assert.Contains(results, x => x.ErrorMessage == "The Solution field is required.");
         Assert.Contains(results, x => x.ErrorMessage == "The RoleSufix field is required.");
         Assert.Contains(results, x => x.ErrorMessage == "The SufixMoundPoint field is required.");
         Assert.Contains(results, x => x.ErrorMessage == "The TemplateConnectionString field is required.");
+        Assert.Contains(results, x => x.ErrorMessage == "The TypeAuth is required.");
     }
 
     [Fact]
@@ -114,5 +114,4 @@ public class VaultOptionsTest
         // Assert
         Assert.Empty(results);
     }
-
 }

--- a/packages/CodeDesignPlus.Net.Vault/tests/CodeDesignPlus.Net.Vault.Test/Services/VaultClientFactoryTest.cs
+++ b/packages/CodeDesignPlus.Net.Vault/tests/CodeDesignPlus.Net.Vault.Test/Services/VaultClientFactoryTest.cs
@@ -13,7 +13,7 @@ public class VaultClientFactoryTest()
 
         // Act
         var exception = Assert.Throws<ArgumentNullException>(() => VaultClientFactory.Create(options));
-        
+
         // Assert
         Assert.Equal("Value cannot be null. (Parameter 'options')", exception.Message);
     }
@@ -40,14 +40,12 @@ public class VaultClientFactoryTest()
     }
 
     [Fact]
-    public void CreateClient_KubernetesEnableIsTrue_ReturnVaultClient()
+    public void CreateClient_KubernetesAuth_ReturnVaultClient()
     {
         // Arrange
         var options = new VaultOptions
         {
             Address = "http://localhost:8200",
-            RoleId = "role-id",
-            SecretId = "secret-id",
             AppName = "app-name"
         };
 
@@ -59,5 +57,22 @@ public class VaultClientFactoryTest()
 
         // Assert
         Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void CreateClient_ThrowVaultException_InvalidAuth()
+    {
+        // Arrange
+        var options = new VaultOptions
+        {
+            Address = "http://localhost:8200",
+            AppName = "app-name"
+        };
+
+        // Act
+        var exception = Assert.Throws<VaultException>(() => VaultClientFactory.Create(options));
+
+        // Assert
+        Assert.Equal("The authentication type is not defined.", exception.Message);
     }
 }

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/CodeDesignPlus.Net.xUnit.csproj
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/CodeDesignPlus.Net.xUnit.csproj
@@ -99,7 +99,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Helpers\VaultContainer\resources\" />
-  </ItemGroup>
 </Project>

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Helpers/VaultContainer/docker-compose.yml
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Helpers/VaultContainer/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: hashicorp/vault:latest
     ports:
       - "0:8200"
-    restart: unless-stopped
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: "root"
       VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
@@ -18,8 +17,9 @@ services:
       - ./resources/entrypoint.sh:/resources/entrypoint.sh
     cap_add:
       - IPC_LOCK
-    command: /bin/sh -c "chmod +x /resources/entrypoint.sh && chmod +x /resources/config.sh && /resources/entrypoint.sh"
-  
+    entrypoint: /bin/sh -c "chmod +x /resources/entrypoint.sh && chmod +x /resources/config.sh && /resources/entrypoint.sh" 
+
+
   mongo:
     image: mongo:latest
     environment:

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Helpers/VaultContainer/resources/config.sh
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Helpers/VaultContainer/resources/config.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 export VAULT_ADDR="http://0.0.0.0:8200"
 
 vault login token=root

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Helpers/VaultContainer/resources/entrypoint.sh
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Helpers/VaultContainer/resources/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+echo "Hello, world!"
 
 echo "Starting Vault server in dev mode..."
 vault server -dev &

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Helpers/VaultContainer/shared/vault-config/credentials.json
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Helpers/VaultContainer/shared/vault-config/credentials.json
@@ -1,4 +1,4 @@
 {
-  "role_id": "39d25686-e06b-a1ff-93a7-35eba37e7c6e",
-  "secret_id": "66615763-1ed1-4963-7ca7-c9d25778b1ab"
+  "role_id": "d02c6882-3189-a9b7-7dab-8eef2ead8d60",
+  "secret_id": "382b241b-3446-49b6-30d4-958abed58665"
 }


### PR DESCRIPTION
This pull request introduces a new `TypeAuth` enum to handle different authentication types in the Vault and refactors the `VaultOptions` class to use this new enum. Additionally, it updates the `VaultClientFactory` to create clients based on the authentication type and modifies the test cases to reflect these changes. Minor updates were also made to the `docker-compose.yml` and related scripts.

### Authentication Enhancements:
* Added `TypeAuth` enum to `packages/CodeDesignPlus.Net.Vault/src/CodeDesignPlus.Net.Vault.Abstractions/Options/TypeAuth.cs` to define different authentication types for the Vault.
* Updated `VaultOptions` class to include a `TypeAuth` property that determines the authentication type based on the provided credentials.
* Modified `VaultClientFactory` to create clients based on the `TypeAuth` value and throw an exception if the authentication type is not defined.

### Validation and Exception Handling:
* Updated the `Validate` method in `VaultOptions` to check for `TypeAuth.None` and add a validation error if no authentication type is specified.
* Added test cases in `VaultOptionsTest` to validate the new `TypeAuth` property and ensure proper error handling for invalid authentication types. [[1]](diffhunk://#diff-3b38b3116e9d3d307e0a368957bfd741c0732ffd62c650bb506a5a13715c9c6fL58-R63) [[2]](diffhunk://#diff-3b38b3116e9d3d307e0a368957bfd741c0732ffd62c650bb506a5a13715c9c6fL117)

### Test Enhancements:
* Added new test cases in `VaultClientFactoryTest` to verify client creation based on different authentication types and to handle invalid authentication scenarios. [[1]](diffhunk://#diff-c39e5584d2620e2d16cef0579341932502955b42d76dfd7b4ca2195fb0edf3b7L43-L50) [[2]](diffhunk://#diff-c39e5584d2620e2d16cef0579341932502955b42d76dfd7b4ca2195fb0edf3b7R61-R77)
* Included a new test case in `VaultExtensionsTest` to verify the configuration builder with token-based authentication.

### Configuration and Script Updates:
* Minor updates to `docker-compose.yml` to change `command` to `entrypoint` for better script execution. [[1]](diffhunk://#diff-4f30800f7af4b8e1a711148f6316a48406e8316bc01752c432a060bad6b83693L8) [[2]](diffhunk://#diff-4f30800f7af4b8e1a711148f6316a48406e8316bc01752c432a060bad6b83693L21-R21)
* Added a new `config.sh` script to set up Vault configuration.
* Modified `entrypoint.sh` to include a greeting message and start the Vault server.
* Updated credentials in `credentials.json` for testing purposes.