### PR TITLE
eat(net.mongo): :bug: check if serializer guid is register

### DIFF
--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
@@ -40,6 +40,9 @@ public static class ServiceCollectionExtensions
                 x.EnableCommandText = options.Diagnostic.EnableCommandText;
             });
 
+        if (BsonSerializer.LookupSerializer(typeof(Guid)) == null)
+            BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
+
         services.AddSingleton<IMongoClient>((serviceProvider) =>
         {
             var mongoUrl = MongoUrl.Create(options.ConnectionString);
@@ -53,8 +56,6 @@ public static class ServiceCollectionExtensions
                 };
 
             var mongoClient = new MongoClient(clientSettings);
-
-            BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
 
             return mongoClient;
         });


### PR DESCRIPTION
This pull request includes a change to the `AddMongo` method in the `ServiceCollectionExtensions.cs` file to ensure that the `GuidSerializer` is registered only if it hasn't been registered already. This improves the robustness of the MongoDB setup in the project.

Improvements to MongoDB setup:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-d24305e8bb2351a50d429aba125542a6437e2ffa5d89bdb7f4cc32e5d533a20fR43-R45): Added a check to see if the `GuidSerializer` is already registered before registering it, ensuring no duplicate registrations. [[1]](diffhunk://#diff-d24305e8bb2351a50d429aba125542a6437e2ffa5d89bdb7f4cc32e5d533a20fR43-R45) [[2]](diffhunk://#diff-d24305e8bb2351a50d429aba125542a6437e2ffa5d89bdb7f4cc32e5d533a20fL57-L58)