### PR TITLE
update configuration

### DIFF
--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Server/Server.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Server/Server.cs
@@ -39,7 +39,7 @@ public class Server<TProgram> : WebApplicationFactory<TProgram> where TProgram :
             {"Redis:Instances:Core:ConnectionString", $"{Compose.Redis.Item1}:{Compose.Redis.Item2}"},
             {"RabbitMQ:Host", Compose.RabbitMQ.Item1},
             {"RabbitMQ:Port", Compose.RabbitMQ.Item2.ToString()},
-            {"MongoDB:ConnectionString", $"mongodb://{Compose.Mongo.Item1}:{Compose.Mongo.Item2}"},
+            {"Mongo:ConnectionString", $"mongodb://{Compose.Mongo.Item1}:{Compose.Mongo.Item2}"},
             {"Observability:ServerOtel", $"http://{Compose.Otel.Item1}:{Compose.Otel.Item2}"},
             {"Logger:OTelEndpoint", $"http://{Compose.Otel.Item1}:{Compose.Otel.Item2}" },
         };


### PR DESCRIPTION
This pull request includes a small but important change to the `ConfigureWebHost` method in the `Server.cs` file. The change updates the configuration key for the MongoDB connection string to align with the naming conventions used for other services.

* [`packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Server/Server.cs`](diffhunk://#diff-62e3724c3d955b19943e4898dc20d519dbfdd6a8a6e7d63ae0985e82d3f1f141L42-R42): Changed the configuration key from `MongoDB:ConnectionString` to `Mongo:ConnectionString`.