### PR TITLE
chore(net.mongo): :bug: fix instance mongo client with connection string

### DIFF
--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
@@ -45,11 +45,12 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IMongoClient>((serviceProvider) =>
         {
-            var mongoUrl = MongoUrl.Create(options.ConnectionString);
+            var mongoOptions = serviceProvider.GetRequiredService<IOptions<MongoOptions>>().Value;
+            var mongoUrl = MongoUrl.Create(mongoOptions.ConnectionString);
 
             var clientSettings = MongoClientSettings.FromUrl(mongoUrl);
 
-            if (options.Diagnostic.Enable)
+            if (mongoOptions.Diagnostic.Enable)
                 clientSettings.ClusterConfigurator = builder =>
                 {
                     builder.SubscribeDiagnosticsActivityEventSubscriber(serviceProvider);


### PR DESCRIPTION
This pull request includes a change to the `AddMongo` method in the `ServiceCollectionExtensions` class to improve how MongoDB options are retrieved and used.

Improvements to MongoDB options retrieval:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-d24305e8bb2351a50d429aba125542a6437e2ffa5d89bdb7f4cc32e5d533a20fL48-R53): Changed the retrieval of MongoDB options to use `IOptions<MongoOptions>` from the service provider instead of directly accessing the connection string from `options`. This ensures that the options are properly configured and validated by the dependency injection system.