### PR TITLE
fix: normalize line endings in DtoGeneratorTest for cross-platform co…

### DIFF
--- a/packages/CodeDesignPlus.Net.Generator/tests/CodeDesignPlus.Net.Generator.Test/DtoGeneratorTest.cs
+++ b/packages/CodeDesignPlus.Net.Generator/tests/CodeDesignPlus.Net.Generator.Test/DtoGeneratorTest.cs
@@ -17,6 +17,9 @@ public class DtoGeneratorTest
         // Arrange
         var sourceExpected = "namespace CodeDesignPlus.Microservice.Api.Dtos\r\n{\r\npublic class CreateUserDto\r\n{\r\n\t\t public string? Name { get; set; }\r\n\t\t public int? Age { get; set; }\r\n}\r\n}\r\n";
 
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            sourceExpected = sourceExpected.Replace("\r\n", "\n");
+
         var source = """
         using System;
         


### PR DESCRIPTION
This pull request includes a small but important change to the `Execute_CommandExist_CreateDto` method in the `DtoGeneratorTest.cs` file. The change ensures that the expected source string is correctly formatted based on the operating system.

* [`packages/CodeDesignPlus.Net.Generator/tests/CodeDesignPlus.Net.Generator.Test/DtoGeneratorTest.cs`](diffhunk://#diff-7593fd6ab5290716acf842e26561cf424fe25296f18a4d15505ac3511721a680R20-R22): Added a conditional check to replace `\r\n` with `\n` in the `sourceExpected` string if the platform is not Windows.