### PR TITLE
refactor: enhance code quality and readability across multiple services

### DIFF
--- a/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/RabbitConnection.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/RabbitConnection.cs
@@ -3,6 +3,7 @@
     /// <summary>
     /// Manages the RabbitMQ connection.
     /// </summary>
+    /// <param name="logger">The logger for logging messages.</param>
     public class RabbitConnection(ILogger<RabbitConnection> logger) : IRabbitConnection
     {
         /// <summary>

--- a/packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Extensions/ServiceCollectionExtensions.cs
@@ -21,11 +21,8 @@ public static class ServiceCollectionExtensions
     /// <returns>The Microsoft.Extensions.DependencyInjection.IServiceCollection so that additional calls can be chained.</returns>
     public static IServiceCollection AddCache(this IServiceCollection services, IConfiguration configuration)
     {
-        if (services == null)
-            throw new ArgumentNullException(nameof(services));
-
-        if (configuration == null)
-            throw new ArgumentNullException(nameof(configuration));
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
 
         var section = configuration.GetSection(RedisCacheOptions.Section);
 

--- a/packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/Services/RedisService.cs
+++ b/packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/Services/RedisService.cs
@@ -89,9 +89,9 @@ public class RedisService : Abstractions.IRedis
     private static X509Certificate2 CertificateSelection(string passwordCertificate, string certificate)
     {
         if (!string.IsNullOrEmpty(passwordCertificate))
-            return new X509Certificate2(certificate, passwordCertificate);
+            return X509CertificateLoader.LoadPkcs12FromFile(certificate, passwordCertificate);
         else
-            return new X509Certificate2(certificate);
+            return X509CertificateLoader.LoadPkcs12FromFile(certificate, null);
     }
 
     /// <summary>
@@ -109,8 +109,7 @@ public class RedisService : Abstractions.IRedis
 
         var serverCACertThumbprint = chain.ChainElements[^1].Certificate.Thumbprint;
 
-        var clientCertCollection = new X509Certificate2Collection();
-        clientCertCollection.Import(certificate, passwordCertificate, X509KeyStorageFlags.DefaultKeySet);
+        var clientCertCollection = X509CertificateLoader.LoadPkcs12CollectionFromFile(certificate, passwordCertificate, X509KeyStorageFlags.DefaultKeySet);
 
         var clientCert = clientCertCollection.OfType<X509Certificate2>().FirstOrDefault(cert => cert.HasPrivateKey);
 

--- a/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security.Abstractions/Options/SecurityOptions.cs
+++ b/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security.Abstractions/Options/SecurityOptions.cs
@@ -87,6 +87,6 @@ public class SecurityOptions
         if (!File.Exists(path))
             throw new FileNotFoundException($"The certificate file not found in the path: {path}");
 
-        return new X509Certificate2(this.CertificatePath, this.CertificatePassword);
+        return X509CertificateLoader.LoadPkcs12FromFile(path, this.CertificatePassword);
     }
 }

--- a/packages/CodeDesignPlus.Net.Serializers/src/CodeDesignPlus.Net.Serializers/JsonValidate.cs
+++ b/packages/CodeDesignPlus.Net.Serializers/src/CodeDesignPlus.Net.Serializers/JsonValidate.cs
@@ -5,7 +5,7 @@ namespace CodeDesignPlus.Net.Serializers;
 /// <summary>
 /// Provides methods for validating JSON strings.
 /// </summary>
-public class JsonValidate
+public static class JsonValidate
 {
     /// <summary>
     /// Determines whether the specified JSON string is valid.

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/SqlServer/SqlCollectionFixture.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/SqlServer/SqlCollectionFixture.cs
@@ -24,9 +24,6 @@ public sealed class SqlCollectionFixture : IDisposable
     {
         this.Container = new SqlServerContainer();
 
-        // Set the security protocol to TLS 1.2.
-        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
         // Wait for the SQL Server container to be fully initialized.
         Thread.Sleep(10000);
     }

--- a/packages/CodeDesignPlus.Net.xUnit/tests/CodeDesignPlus.Net.xUnit.Test/MongoContainerTest.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/tests/CodeDesignPlus.Net.xUnit.Test/MongoContainerTest.cs
@@ -1,5 +1,8 @@
 ﻿using CodeDesignPlus.Net.xUnit.Containers.MongoContainer;
 using CodeDesignPlus.Net.xUnit.Test.Helpers;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
 
 namespace CodeDesignPlus.Net.xUnit.Test;
@@ -12,6 +15,7 @@ public class MongoContainerTest(MongoCollectionFixture mongoCollectionFixture)
     [Fact]
     public async Task CheckConnectionServer()
     {
+        BsonSerializer.TryRegisterSerializer<Guid>(new GuidSerializer(GuidRepresentation.Standard));
         var host = "localhost";
         var port = this.mongoContainer.Port;
         var databaseName = "dbtestmongo";

--- a/packages/CodeDesignPlus.Net.xUnit/tests/CodeDesignPlus.Net.xUnit.Test/VaultContainerTest.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/tests/CodeDesignPlus.Net.xUnit.Test/VaultContainerTest.cs
@@ -12,14 +12,14 @@ public class VaultContainerTest(VaultCollectionFixture fixture)
     [Fact]
     public async Task CheckConnectionService()
     {
-        IAuthMethodInfo authMethod = new AppRoleAuthMethodInfo(fixture.Container.Credentials.RoleId, fixture.Container.Credentials.SecretId);
+        var authMethod = new AppRoleAuthMethodInfo(fixture.Container.Credentials.RoleId, fixture.Container.Credentials.SecretId);
         var vaultClientSettings = new VaultClientSettings($"http://localhost:{fixture.Container.Port}", authMethod);
 
-        IVaultClient vaultClient = new VaultClient(vaultClientSettings);
+        var vaultClient = new VaultClient(vaultClientSettings);
 
         var kv1Secret = await vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync("my-app", mountPoint: "unit-test-keyvalue");
 
         Assert.True(kv1Secret.Data.Data.ContainsKey("Security:ClientId"));
-        Assert.Equal("a74cb192-598c-4757-95ae-b315793bbbca", kv1Secret.Data.Data["Security:ClientId"]);
+        Assert.Equal("a74cb192-598c-4757-95ae-b315793bbbca", kv1Secret.Data.Data["Security:ClientId"].ToString());
     }
 }


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve code readability, consistency, and functionality. The most important changes are grouped by theme and summarized below:

### Code Refactoring and Improvement:
* [`packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-2101b71c0733e818133af8fb5a3d8e25c9f584fdcc1eb8dbfa5cf577f5efb097L24-R25): Replaced manual null checks with `ArgumentNullException.ThrowIfNull` for better readability and consistency.
* [`packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security.Abstractions/Options/SecurityOptions.cs`](diffhunk://#diff-606f17da09e5e25b870a6a5afd8e00c80bf8cb5202b0264bf25720d5accce512L90-R90): Updated certificate loading to use `X509CertificateLoader.LoadPkcs12FromFile` for improved security and consistency.
* [`packages/CodeDesignPlus.Net.Serializers/src/CodeDesignPlus.Net.Serializers/JsonValidate.cs`](diffhunk://#diff-abeb2a37abfd1c6cf609fffd4292bd12d0aa3b64d4a7300371604318145922b5L8-R8): Changed `JsonValidate` class to be static as it only contains static methods.

### Functionality Enhancements:
* [`packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/Services/RedisService.cs`](diffhunk://#diff-45bc6f526f1b02bb5d80ddb0b1d8d401417942fdf2135f5eb89b18fab62c7624L92-R94): Updated certificate loading methods to use `X509CertificateLoader` for improved handling of PKCS#12 certificates. [[1]](diffhunk://#diff-45bc6f526f1b02bb5d80ddb0b1d8d401417942fdf2135f5eb89b18fab62c7624L92-R94) [[2]](diffhunk://#diff-45bc6f526f1b02bb5d80ddb0b1d8d401417942fdf2135f5eb89b18fab62c7624L112-R112)

### Test Improvements:
* [`packages/CodeDesignPlus.Net.xUnit/tests/CodeDesignPlus.Net.xUnit.Test/MongoContainerTest.cs`](diffhunk://#diff-1d9893743845edf744779535669a2a7df44789eef15206624d295e2b7c99589eR18): Registered a `GuidSerializer` for BSON serialization to ensure proper handling of `Guid` values in MongoDB tests.
* [`packages/CodeDesignPlus.Net.xUnit/tests/CodeDesignPlus.Net.xUnit.Test/VaultContainerTest.cs`](diffhunk://#diff-b97df0be869eb290a7f47e174d40ce700f12c6fe43a96bd11cd7414daf6638c3L15-R23): Simplified variable declarations by using `var` and ensured `Security:ClientId` is correctly compared as a string.