### PR TITLE
refactor: remove IncludeBuildOutput property from project file

### DIFF
--- a/packages/CodeDesignPlus.Net.Generator/src/CodeDesignPlus.Net.Generator/CodeDesignPlus.Net.Generator.csproj
+++ b/packages/CodeDesignPlus.Net.Generator/src/CodeDesignPlus.Net.Generator/CodeDesignPlus.Net.Generator.csproj
@@ -2,7 +2,6 @@
 	<PropertyGroup>
 		<LangVersion>9</LangVersion>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<Authors>CodeDesignPlus</Authors>
 		<Description>CodeDesignPlus.Net.Generator provides a powerful framework for generating code in .NET Core applications. This library simplifies the process of creating boilerplate code, enabling developers to increase productivity and maintain consistency across their projects.</Description>
 		<Copyright>© CodeDesignPlus. All rights reserved.</Copyright>


### PR DESCRIPTION
This pull request includes a small change to the `CodeDesignPlus.Net.Generator.csproj` file. The change removes the `<IncludeBuildOutput>` property from the project file.

Changes in project file:

* [`packages/CodeDesignPlus.Net.Generator/src/CodeDesignPlus.Net.Generator/CodeDesignPlus.Net.Generator.csproj`](diffhunk://#diff-0cbb14a604f5e72cfff23e309e8ff5d2237dc1ffdaddaa6ab45259c60cdafda9L5): Removed the `<IncludeBuildOutput>` property.