### PR TITLE
fix warnings and add standard key cache

### DIFF
--- a/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/RabbitConnection.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/RabbitConnection.cs
@@ -16,7 +16,7 @@
         /// <summary>
         /// Connects to the RabbitMQ server.
         /// </summary>
-        /// <param name="logger">The logger for logging messages.</param>
+        /// <param name="appName">The name of the application.</param>
         /// <param name="settings">The options for configuring the RabbitMQ connection.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="settings"/> or <paramref name="appName"/> is null.</exception>

--- a/packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Services/RedisCacheManager.cs
+++ b/packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Services/RedisCacheManager.cs
@@ -134,7 +134,7 @@ public class RedisCacheManager(IRedisFactory factory, ILogger<RedisCacheManager>
         if (string.IsNullOrEmpty(key))
             ArgumentNullException.ThrowIfNull(key);
 
-        if(value == null)
+        if (EqualityComparer<T>.Default.Equals(value, default))
             ArgumentNullException.ThrowIfNull(value);
 
         var internalKey = GetKey(key);

--- a/packages/CodeDesignPlus.Net.Redis.Cache/tests/CodeDesignPlus.Net.Redis.Cache.Test/Services/RedisCacheManagerIntegrationTest.cs
+++ b/packages/CodeDesignPlus.Net.Redis.Cache/tests/CodeDesignPlus.Net.Redis.Cache.Test/Services/RedisCacheManagerIntegrationTest.cs
@@ -1,4 +1,5 @@
 using System;
+using CodeDesignPlus.Net.Core.Abstractions.Options;
 using CodeDesignPlus.Net.Redis.Abstractions;
 using CodeDesignPlus.Net.Redis.Cache.Abstractions.Options;
 using CodeDesignPlus.Net.Redis.Cache.Test.Helpers;
@@ -8,8 +9,33 @@ using O = Microsoft.Extensions.Options;
 
 namespace CodeDesignPlus.Net.Redis.Cache.Test.Services;
 
-public class RedisCacheManagerIntegrationTest(RedisContainer fixture) : IClassFixture<RedisContainer>
+public class RedisCacheManagerIntegrationTest : IClassFixture<RedisContainer>
 {
+    private readonly RedisContainer fixture;
+    private readonly CoreOptions core ;
+
+    private readonly IOptions<CoreOptions> coreOptions;
+
+    public RedisCacheManagerIntegrationTest(RedisContainer fixture)
+    {
+        this.fixture = fixture;
+        
+        this.core = new ()
+        {
+            AppName = "ms-test",
+                Business = "CodeDesignPlus",
+                Description = "Unit test",
+                Version = "1",
+                Contact = new Contact()
+                {
+                    Email = "codedesignplus@codedesignplus.com",
+                    Name = "CodeDesignPlus"
+                }
+        };
+
+        this.coreOptions = Microsoft.Extensions.Options.Options.Create(core);
+    }
+    
     [Fact]
     public async Task SetAsync_GetAsync_Success()
     {
@@ -21,7 +47,7 @@ public class RedisCacheManagerIntegrationTest(RedisContainer fixture) : IClassFi
         var redisFactory = new Mock<IRedisFactory>();
         redisFactory.Setup(x => x.Create(FactoryConst.RedisCore)).Returns(redisService);
 
-        var redisCacheManager = new RedisCacheManager(redisFactory.Object, Mock.Of<ILogger<RedisCacheManager>>(), O.Options.Create(new RedisCacheOptions()));
+        var redisCacheManager = new RedisCacheManager(redisFactory.Object, Mock.Of<ILogger<RedisCacheManager>>(), O.Options.Create(new RedisCacheOptions()), coreOptions);
 
         // Act
         await redisCacheManager.SetAsync(expected, value, TimeSpan.FromMinutes(5));
@@ -43,7 +69,7 @@ public class RedisCacheManagerIntegrationTest(RedisContainer fixture) : IClassFi
         var redisFactory = new Mock<IRedisFactory>();
         redisFactory.Setup(x => x.Create(FactoryConst.RedisCore)).Returns(redisService);
 
-        var redisCacheManager = new RedisCacheManager(redisFactory.Object, Mock.Of<ILogger<RedisCacheManager>>(), O.Options.Create(new RedisCacheOptions()));
+        var redisCacheManager = new RedisCacheManager(redisFactory.Object, Mock.Of<ILogger<RedisCacheManager>>(), O.Options.Create(new RedisCacheOptions()), coreOptions);
 
         // Act
         await redisCacheManager.SetAsync(expected, value, TimeSpan.FromMinutes(5));
@@ -65,7 +91,7 @@ public class RedisCacheManagerIntegrationTest(RedisContainer fixture) : IClassFi
         var redisFactory = new Mock<IRedisFactory>();
         redisFactory.Setup(x => x.Create(FactoryConst.RedisCore)).Returns(redisService);
 
-        var redisCacheManager = new RedisCacheManager(redisFactory.Object, Mock.Of<ILogger<RedisCacheManager>>(), O.Options.Create(new RedisCacheOptions()));
+        var redisCacheManager = new RedisCacheManager(redisFactory.Object, Mock.Of<ILogger<RedisCacheManager>>(), O.Options.Create(new RedisCacheOptions()), coreOptions);
 
         // Act
         await redisCacheManager.SetAsync(expected, value, TimeSpan.FromMinutes(5));
@@ -89,7 +115,7 @@ public class RedisCacheManagerIntegrationTest(RedisContainer fixture) : IClassFi
         var redisFactory = new Mock<IRedisFactory>();
         redisFactory.Setup(x => x.Create(FactoryConst.RedisCore)).Returns(redisService);
 
-        var redisCacheManager = new RedisCacheManager(redisFactory.Object, Mock.Of<ILogger<RedisCacheManager>>(), O.Options.Create(new RedisCacheOptions()));
+        var redisCacheManager = new RedisCacheManager(redisFactory.Object, Mock.Of<ILogger<RedisCacheManager>>(), O.Options.Create(new RedisCacheOptions()), coreOptions);
 
         // Act
         await redisCacheManager.SetAsync(expected, value, TimeSpan.FromMinutes(5));


### PR DESCRIPTION
This pull request includes several changes to the `RedisCacheManager` class and its related tests to enhance the handling of Redis keys and improve logging. The most important changes include the introduction of a new method to generate internal keys, updates to method parameters, and modifications to test cases to accommodate these changes.

Enhancements to Redis key handling:

* [`packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Services/RedisCacheManager.cs`](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aR53-R62): Added a new `GetKey` method to generate internal keys using `CoreOptions`. Updated various methods (`ExistsAsync`, `GetAsync`, `RemoveAsync`, `SetAsync`) to use the internal key for Redis operations and logging. [[1]](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aR53-R62) [[2]](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aR77-R90) [[3]](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aR109-R120) [[4]](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aL130-R164)

Updates to method parameters:

* [`packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/RabbitConnection.cs`](diffhunk://#diff-59649beff5868bcf666c0ba5c39b881e09c87202c40cbb00dcbbb20a75a48381L19-R19): Changed the `logger` parameter to `appName` in the `Connects to the RabbitMQ server` method.
* [`packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Services/RedisCacheManager.cs`](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aL16-L19): Added `coreOptions` parameter to the `RedisCacheManager` constructor and updated the `cacheOptions` parameter name.

Modifications to test cases:

* [`packages/CodeDesignPlus.Net.Redis.Cache/tests/CodeDesignPlus.Net.Redis.Cache.Test/Services/RedisCacheManagerIntegrationTest.cs`](diffhunk://#diff-4369de3245695b6afa8eb1918ea78ce69868ac665edd18af18d8bf97ced680e0L11-R38): Updated integration tests to include `coreOptions` and initialize `CoreOptions` in the test class constructor. [[1]](diffhunk://#diff-4369de3245695b6afa8eb1918ea78ce69868ac665edd18af18d8bf97ced680e0L11-R38) [[2]](diffhunk://#diff-4369de3245695b6afa8eb1918ea78ce69868ac665edd18af18d8bf97ced680e0L24-R50) [[3]](diffhunk://#diff-4369de3245695b6afa8eb1918ea78ce69868ac665edd18af18d8bf97ced680e0L46-R72) [[4]](diffhunk://#diff-4369de3245695b6afa8eb1918ea78ce69868ac665edd18af18d8bf97ced680e0L68-R94) [[5]](diffhunk://#diff-4369de3245695b6afa8eb1918ea78ce69868ac665edd18af18d8bf97ced680e0L92-R118)
* [`packages/CodeDesignPlus.Net.Redis.Cache/tests/CodeDesignPlus.Net.Redis.Cache.Test/Services/RedisCacheManagerTest.cs`](diffhunk://#diff-225ef0f3a89f9786a8041dc3c11409eb391fa5978036dc839e0e6138185f4a8dL29-R51): Updated unit tests to include `coreOptions` and initialize `CoreOptions` in the test class constructor. Modified assertions to use the internal key generated by `GetKey`. [[1]](diffhunk://#diff-225ef0f3a89f9786a8041dc3c11409eb391fa5978036dc839e0e6138185f4a8dL29-R51) [[2]](diffhunk://#diff-225ef0f3a89f9786a8041dc3c11409eb391fa5978036dc839e0e6138185f4a8dL52-R74) [[3]](diffhunk://#diff-225ef0f3a89f9786a8041dc3c11409eb391fa5978036dc839e0e6138185f4a8dL70-R92) [[4]](diffhunk://#diff-225ef0f3a89f9786a8041dc3c11409eb391fa5978036dc839e0e6138185f4a8dL92-R120) [[5]](diffhunk://#diff-225ef0f3a89f9786a8041dc3c11409eb391fa5978036dc839e0e6138185f4a8dL116-R144) [[6]](diffhunk://#diff-225ef0f3a89f9786a8041dc3c11409eb391fa5978036dc839e0e6138185f4a8dL134-R156) [[7]](diffhunk://#diff-225ef0f3a89f9786a8041dc3c11409eb391fa5978036dc839e0e6138185f4a8dL156-R184)