### PR TITLE
Feature/fix duplicate key

### DIFF
--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
@@ -40,7 +40,9 @@ public static class ServiceCollectionExtensions
                 x.EnableCommandText = options.Diagnostic.EnableCommandText;
             });
 
-        if (BsonSerializer.LookupSerializer<Guid>() == null)
+        var serializer = BsonSerializer.SerializerRegistry.GetSerializer<GuidSerializer>();
+
+        if (serializer is null)
             BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
 
         services.AddSingleton<IMongoClient>((serviceProvider) =>

--- a/packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Services/RedisCacheManager.cs
+++ b/packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Services/RedisCacheManager.cs
@@ -149,7 +149,7 @@ public class RedisCacheManager(IRedisFactory factory, ILogger<RedisCacheManager>
         if (expiration == null)
             expiration = cacheOptions.Value.Expiration;
 
-        logger.LogDebug("The key {InternalKey} will be stored in the cache for {TotalSeconds} seconds", internalKey, expiration.Value.TotalSeconds);
+        logger.LogDebug("The key {InternalKey} will be stored in the cache for {Expiration.Value.TotalSeconds} seconds", internalKey, expiration.Value.TotalSeconds);
 
         return this.redis.Database.StringSetAsync(internalKey, JsonSerializer.Serialize(value), expiration);
     }

--- a/packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Services/RedisCacheManager.cs
+++ b/packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Services/RedisCacheManager.cs
@@ -54,7 +54,7 @@ public class RedisCacheManager(IRedisFactory factory, ILogger<RedisCacheManager>
 
         if (this.redis.Database == null)
         {
-            logger.LogWarning("The key {Key} could not be verified because the connection to the Redis server could not be established", internalKey);
+            logger.LogWarning("The key {InternalKey} could not be verified because the connection to the Redis server could not be established", internalKey);
 
             return Task.FromResult(false);
         }
@@ -78,7 +78,7 @@ public class RedisCacheManager(IRedisFactory factory, ILogger<RedisCacheManager>
 
         if (this.redis.Database == null)
         {
-            logger.LogWarning("The key {Key} could not be retrieved because the connection to the Redis server could not be established", internalKey);
+            logger.LogWarning("The key {InternalKey} could not be retrieved because the connection to the Redis server could not be established", internalKey);
 
             return default;
         }
@@ -87,7 +87,7 @@ public class RedisCacheManager(IRedisFactory factory, ILogger<RedisCacheManager>
 
         if (data.IsNullOrEmpty)
         {
-            logger.LogDebug("The key {Key} does not exist in the cache", internalKey);
+            logger.LogDebug("The key {InternalKey} does not exist in the cache", internalKey);
 
             return default;
         }
@@ -110,12 +110,12 @@ public class RedisCacheManager(IRedisFactory factory, ILogger<RedisCacheManager>
 
         if (this.redis.Database == null)
         {
-            logger.LogWarning("The key {Key} could not be removed because the connection to the Redis server could not be established", internalKey);
+            logger.LogWarning("The key {InternalKey} could not be removed because the connection to the Redis server could not be established", internalKey);
 
             return Task.CompletedTask;
         }
 
-        logger.LogDebug("The key {Key} will be removed from the cache", internalKey);
+        logger.LogDebug("The key {InternalKey} will be removed from the cache", internalKey);
 
         return this.redis.Database.KeyDeleteAsync(internalKey);
     }
@@ -141,7 +141,7 @@ public class RedisCacheManager(IRedisFactory factory, ILogger<RedisCacheManager>
 
         if (this.redis.Database == null)
         {
-            logger.LogWarning("The key {Key} could not be stored because the connection to the Redis server could not be established", internalKey);
+            logger.LogWarning("The key {InternalKey} could not be stored because the connection to the Redis server could not be established", internalKey);
 
             return Task.CompletedTask;
         }
@@ -149,7 +149,7 @@ public class RedisCacheManager(IRedisFactory factory, ILogger<RedisCacheManager>
         if (expiration == null)
             expiration = cacheOptions.Value.Expiration;
 
-        logger.LogDebug("The key {Key} will be stored in the cache for {expiration} seconds", internalKey, expiration.Value.TotalSeconds);
+        logger.LogDebug("The key {InternalKey} will be stored in the cache for {TotalSeconds} seconds", internalKey, expiration.Value.TotalSeconds);
 
         return this.redis.Database.StringSetAsync(internalKey, JsonSerializer.Serialize(value), expiration);
     }


### PR DESCRIPTION
This pull request includes updates to the `CodeDesignPlus.Net.Mongo` and `CodeDesignPlus.Net.Redis.Cache` packages, focusing on improving logging messages and handling BSON serializers. The most important changes include modifying log messages for consistency and checking for existing BSON serializers before registering new ones.

Improvements to logging messages:

* [`packages/CodeDesignPlus.Net.Redis.Cache/src/CodeDesignPlus.Net.Redis.Cache/Services/RedisCacheManager.cs`](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aL57-R57): Updated log messages to consistently use `{InternalKey}` instead of `{Key}` in multiple methods (`ExistsAsync`, `GetAsync`, `RemoveAsync`, `SetAsync`). [[1]](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aL57-R57) [[2]](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aL81-R81) [[3]](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aL90-R90) [[4]](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aL113-R118) [[5]](diffhunk://#diff-8e5baa1fef426d201d16ea06f9f4452b531ac65e6147654752607752b718827aL144-R152)

Handling BSON serializers:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-d24305e8bb2351a50d429aba125542a6437e2ffa5d89bdb7f4cc32e5d533a20fL43-R45): Modified the `AddMongo` method to check for existing `GuidSerializer` using `BsonSerializer.SerializerRegistry.GetSerializer<GuidSerializer>()` before registering a new one.