### PR TITLE
feat: add AddStartups method to IServiceCollection for dynamic startu…

### DIFF
--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Extensions/ServiceCollectionExtensionsTest.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Extensions/ServiceCollectionExtensionsTest.cs
@@ -66,5 +66,19 @@ public class ServiceCollectionExtensionsTest
         Assert.Equal(ConfigurationUtil.CoreOptions.AppName, value.AppName);
     }
 
+    [Fact]
+    public void AddStartups_Success()
+    {
+        // Arrange
+        var configuration = ConfigurationUtil.GetConfiguration();
+
+        var serviceCollection = new ServiceCollection();
+
+        // Act
+        serviceCollection.AddStartups(configuration);
+
+        // Assert
+        Assert.True(StartupFake.Initialized);
+    }
 
 }

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/StartupFake.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/StartupFake.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace CodeDesignPlus.Net.Core.Test.Helpers;
+
+public class StartupFake: IStartup
+{
+    public static bool Initialized { get; private set; }
+
+    public void Initialize(IServiceCollection services, IConfiguration configuration)
+    {
+        Initialized = true;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new method to add services from `IStartup` implementations to the `IServiceCollection` and includes corresponding unit tests to ensure the functionality works as expected. The most important changes are summarized below:

### New Method for Service Collection Extensions

* [`packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-8f8d755c73863113bf9347c2da7f53ec651c6541758929ef8c2b8819d637ce09R35-R58): Added `AddStartups` method to add services from `IStartup` implementations using the provided `IConfiguration`.

### Unit Tests

* [`packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Extensions/ServiceCollectionExtensionsTest.cs`](diffhunk://#diff-1f8365b9fcf41e58791adcdfaac3daafd432a3a3a1be7fbafbd9c2df3ae05ebcR69-R82): Added a new unit test `AddStartups_Success` to verify that `AddStartups` method correctly initializes services.
* [`packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/StartupFake.cs`](diffhunk://#diff-21a7cca0058d8c0a37787538f6b4026e1ffc5695128e57c4155750a0f46a6abdR1-R13): Created `StartupFake` class implementing `IStartup` for testing purposes, with a static `Initialized` property to confirm initialization.