### PR TITLE
Feature/integrate nodatime

### DIFF
--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/AggregateRootBase.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/AggregateRootBase.cs
@@ -20,7 +20,7 @@ public abstract class AggregateRootBase : IAggregateRoot
     /// <summary>
     /// Gets or sets the timestamp when the aggregate root was created.
     /// </summary>
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
 
     /// <summary>
     /// Gets or sets the unique identifier of the user who created the aggregate root.
@@ -30,7 +30,7 @@ public abstract class AggregateRootBase : IAggregateRoot
     /// <summary>
     /// Gets or sets the timestamp when the aggregate root was last updated.
     /// </summary>
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
 
     /// <summary>
     /// Gets or sets the unique identifier of the user who last updated the aggregate root.

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/CodeDesignPlus.Net.Core.Abstractions.csproj
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/CodeDesignPlus.Net.Core.Abstractions.csproj
@@ -36,5 +36,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="NodaTime" Version="3.2.1" />
   </ItemGroup>
 </Project>

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/DomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/DomainEvent.cs
@@ -17,7 +17,7 @@
 public abstract class DomainEvent(
     Guid aggregateId,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : IDomainEvent
 {
@@ -50,7 +50,7 @@ public abstract class DomainEvent(
     /// This property is internal and can only be set within the assembly.
     /// If not provided during initialization, the current UTC date and time will be used.
     /// </remarks>
-    public DateTime OccurredAt { get; internal set; } = occurredAt ?? DateTime.UtcNow;
+    public Instant OccurredAt { get; internal set; } = occurredAt ?? SystemClock.Instance.GetCurrentInstant();
 
     /// <summary>
     /// Gets or sets the additional metadata associated with the event.

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/IDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/IDomainEvent.cs
@@ -13,7 +13,7 @@ public interface IDomainEvent
     /// <summary>
     /// Gets the date and time when the event occurred.
     /// </summary>
-    DateTime OccurredAt { get; }
+    Instant OccurredAt { get; }
 
     /// <summary>
     /// Gets the unique identifier of the aggregate associated with the event.

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/IEntity.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/IEntity.cs
@@ -26,7 +26,7 @@ public interface IEntity : IEntityBase
     /// <summary>
     /// Get or sets the creatae at
     /// </summary>
-    long CreatedAt { get; set; }
+    Instant CreatedAt { get; set; }
     /// <summary>
     /// Get or sets the create by
     /// </summary>
@@ -34,7 +34,7 @@ public interface IEntity : IEntityBase
     /// <summary>
     /// Get or sets the update at
     /// </summary>
-    long? UpdatedAt { get; set; }
+    Instant? UpdatedAt { get; set; }
     /// <summary>
     /// Get or sets the update by
     /// </summary>

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/Usings.cs
@@ -1,5 +1,5 @@
-﻿
-global using Microsoft.Extensions.Configuration;
+﻿global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
 global using System.Collections.Concurrent;
 global using System.ComponentModel.DataAnnotations;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core/Usings.cs
@@ -10,4 +10,3 @@ global using System.Linq;
 global using System.Reflection;
 global using Microsoft.Extensions.DependencyInjection.Extensions;
 global using Microsoft.Extensions.Options;
-

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Abstractions/AggregateRootTest.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Abstractions/AggregateRootTest.cs
@@ -40,8 +40,8 @@ public class AggregateRootTest
         Assert.Equal("Test 2", orderAggregate.Name);
         Assert.Equal("Test Description 2", orderAggregate.Description);
         Assert.Equal(20, orderAggregate.Price);
-        Assert.True(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() > orderAggregate.CreatedAt);
-        Assert.True(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() > orderAggregate.UpdatedAt);
+        Assert.True(SystemClock.Instance.GetCurrentInstant() > orderAggregate.CreatedAt);
+        Assert.True(SystemClock.Instance.GetCurrentInstant() > orderAggregate.UpdatedAt);
         Assert.True(orderAggregate.IsActive);
         Assert.Equal(tenant, orderAggregate.Tenant);
 
@@ -51,7 +51,7 @@ public class AggregateRootTest
 
         await Task.Delay(100);
 
-        Assert.True(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() > orderAggregate.UpdatedAt);
+        Assert.True(SystemClock.Instance.GetCurrentInstant() > orderAggregate.UpdatedAt);
 
         var events = orderAggregate.GetAndClearEvents();
 

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Abstractions/DomainEventTest.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Abstractions/DomainEventTest.cs
@@ -12,9 +12,9 @@ public class DomainEventTest
         var name = "Name";
         var description = "Description";
         var price = 100;
-        var createdAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var createdAt = SystemClock.Instance.GetCurrentInstant();
         var createBy = Guid.NewGuid();
-        var updatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var updatedAt = SystemClock.Instance.GetCurrentInstant();
         var metadata = new Dictionary<string, object>
         {
             { "key", "value" }
@@ -33,7 +33,7 @@ public class DomainEventTest
         Assert.Equal(createdAt, domainEvent.CreatedAt);
         Assert.Equal(createBy, domainEvent.CreateBy);
         Assert.Equal(updatedAt, domainEvent.UpdatedAt);
-        Assert.True(DateTime.UtcNow > domainEvent.OccurredAt);
+        Assert.True(SystemClock.Instance.GetCurrentInstant() > domainEvent.OccurredAt);
         Assert.Equal(metadata, domainEvent.Metadata);
     }
 
@@ -45,11 +45,11 @@ public class DomainEventTest
         var name = "Name";
         var description = "Description";
         var price = 100;
-        var createdAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var createdAt = SystemClock.Instance.GetCurrentInstant();
         var createBy = Guid.NewGuid();
-        var updatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var updatedAt = SystemClock.Instance.GetCurrentInstant();
         var eventId = Guid.NewGuid();
-        var occurredAt = DateTime.UtcNow;
+        var occurredAt = SystemClock.Instance.GetCurrentInstant();
         var metadata = new Dictionary<string, object>
         {
             { "key", "value" }

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Context/FakeEntity.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Context/FakeEntity.cs
@@ -5,9 +5,9 @@
         public Guid Id { get; set; }
         public string? Name { get; set; }
         public Guid Tenant { get; set; }
-        public long CreatedAt { get; set; }
+        public Instant CreatedAt { get; set; }
         public Guid CreatedBy { get; set; }
-        public long? UpdatedAt { get; set; }
+        public Instant? UpdatedAt { get; set; }
         public Guid? UpdatedBy { get; set; }
         public bool IsActive { get; set; }
     }

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/CategoryCreatedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/CategoryCreatedDomainEvent.cs
@@ -1,4 +1,5 @@
 using System;
+using NodaTime;
 
 namespace CodeDesignPlus.Net.Core.Test.Helpers.Domain;
 
@@ -9,7 +10,7 @@ public class CategoryCreatedDomainEvent
     Guid id,
     string name,
     Guid? eventId = null,
-    DateTime? occurredAt = null
+    Instant? occurredAt = null
 ) : DomainEvent(id, eventId, occurredAt)
 {
 

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/DaminEventWithEventKey.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/DaminEventWithEventKey.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace CodeDesignPlus.Net.Core.Test.Helpers.Domain;
 
-public class DaminEventWithEventKey(Guid aggregateId, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object>? metadata = null)
+public class DaminEventWithEventKey(Guid aggregateId, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object>? metadata = null)
     : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
 }

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/OrderAggregate.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/OrderAggregate.cs
@@ -26,13 +26,13 @@ public class OrderAggregate : AggregateRoot
     {
         var aggregate = new OrderAggregate(id, name, description, price)
         {
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             CreatedBy = createBy,
             IsActive = true,
             Tenant = tenant
         };
 
-        aggregate.AddEvent(new OrderCreatedDomainEvent(id, name, description, price, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), createBy, null, metadata: new Dictionary<string, object>
+        aggregate.AddEvent(new OrderCreatedDomainEvent(id, name, description, price, SystemClock.Instance.GetCurrentInstant(), createBy, null, metadata: new Dictionary<string, object>
         {
             { "MetaKey1", "Value1" }
         }));
@@ -45,7 +45,7 @@ public class OrderAggregate : AggregateRoot
         Name = name;
         Description = description;
         Price = price;
-        UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        UpdatedAt = SystemClock.Instance.GetCurrentInstant();
         UpdatedBy = updatedBy;
 
         AddEvent(new OrderUpdatedDomainEvent(Id, name, description, price, UpdatedAt, updatedBy));
@@ -53,7 +53,7 @@ public class OrderAggregate : AggregateRoot
 
     public void Delete()
     {
-        UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        UpdatedAt = SystemClock.Instance.GetCurrentInstant();
 
         AddEvent(new OrderDeletedDomainEvent(Id, UpdatedAt));
     }

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/OrderCreatedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/OrderCreatedDomainEvent.cs
@@ -6,18 +6,18 @@ public class OrderCreatedDomainEvent(
     string name,
     string description,
     decimal price,
-    long createdAt,
+    Instant createdAt,
     Guid createBy,
-    long? updatedAt,
+    Instant? updatedAt,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
     ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public string Name { get; private set; } = name;
     public string Description { get; private set; } = description;
     public decimal Price { get; private set; } = price;
-    public long CreatedAt { get; private set; } = createdAt;
+    public Instant CreatedAt { get; private set; } = createdAt;
     public Guid CreateBy { get; private set; } = createBy;
-    public long? UpdatedAt { get; private set; } = updatedAt;
+    public Instant? UpdatedAt { get; private set; } = updatedAt;
 }

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/OrderDeletedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/OrderDeletedDomainEvent.cs
@@ -3,10 +3,10 @@
 [EventKey<OrderAggregate>(1, "deleted")]
 public class OrderDeletedDomainEvent(
     Guid id,
-    long? deletedAt,
+    Instant? deletedAt,
     Guid? eventId = null,
-    DateTime? occurredAt = null
+    Instant? occurredAt = null
 ) : DomainEvent(id, eventId, occurredAt)
 {
-    public long? DeletedAt { get; private set; } = deletedAt;
+    public Instant? DeletedAt { get; private set; } = deletedAt;
 }

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/OrderUpdatedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/OrderUpdatedDomainEvent.cs
@@ -6,10 +6,10 @@ public class OrderUpdatedDomainEvent(
     string name,
     string description,
     decimal price,
-    long? updatedAt,
+    Instant? updatedAt,
     Guid UpdatedBy,
     Guid? eventId = null,
-    DateTime? occurredAt = null
+    Instant? occurredAt = null
 ) : DomainEvent(id, eventId, occurredAt)
 {
     private readonly Guid updatedBy = UpdatedBy;
@@ -17,5 +17,5 @@ public class OrderUpdatedDomainEvent(
     public string Name { get; private set; } = name;
     public string Description { get; private set; } = description;
     public decimal Price { get; private set; } = price;
-    public long? UpdatedAt { get; private set; } = updatedAt;
+    public Instant? UpdatedAt { get; private set; } = updatedAt;
 }

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Models/Pager/PagerTest.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Models/Pager/PagerTest.cs
@@ -160,7 +160,7 @@ namespace CodeDesignPlus.Net.Core.Test.Models.Pager
                     Name = $"Fake - {i}",
                     IsActive = true,
                     CreatedBy = Guid.NewGuid(),
-                    CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 });
             }
             await fakeContext.FakeEntity.AddRangeAsync(entities);

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Usings.cs
@@ -10,3 +10,4 @@ global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Options;
 global using System.Text;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.Criteria/src/CodeDesignPlus.Net.Criteria/Evaluator.cs
+++ b/packages/CodeDesignPlus.Net.Criteria/src/CodeDesignPlus.Net.Criteria/Evaluator.cs
@@ -1,10 +1,14 @@
-﻿namespace CodeDesignPlus.Net.Criteria;
+﻿using NodaTime;
+using NodaTime.Text;
+
+namespace CodeDesignPlus.Net.Criteria;
 
 /// <summary>
 /// Evaluates an abstract syntax tree (AST) and builds an expression to represent the evaluation.
 /// </summary>
 internal static class Evaluator
 {
+    private static readonly InstantPattern pattern = InstantPattern.CreateWithInvariantCulture("yyyy-MM-ddTHH:mm:ss'Z'");
     private static readonly string[] Operators = ["~=", "^=", "$=", "<=", ">=", "=", "<", ">"];
 
     /// <summary>
@@ -119,6 +123,13 @@ internal static class Evaluator
     {
         try
         {
+            if (targetType == typeof(Instant))
+            {
+                var parseResult = pattern.Parse(value);
+
+                return Expression.Constant(parseResult.Value, targetType);
+            }
+
             var convertedValue = Convert.ChangeType(value, targetType);
             return Expression.Constant(convertedValue, targetType);
         }

--- a/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Extensions/CriteriaExtensionsTest.cs
+++ b/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Extensions/CriteriaExtensionsTest.cs
@@ -215,7 +215,7 @@ public class CriteriaExtensionsTest
     public void GetFilterExpression_OperatorEqualWithDateTime_ReturnsNotNull()
     {
         // Arrange
-        var date = new DateTime(2021, 1, 1);
+        var date = new LocalDate(2021, 1, 1).AtMidnight().InUtc().ToInstant();
         var orderExpected = this.orders.FirstOrDefault(x => x.CreatedAt == date);
         var criteria = new MC.Criteria { Filters = $"CreatedAt={date}" };
 

--- a/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Helpers/Models/Order.cs
+++ b/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Helpers/Models/Order.cs
@@ -10,7 +10,7 @@ public class Order
 
     public decimal Total { get; set; }
 
-    public DateTime CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
 
     public List<Product> Products { get; set; } = [];
 

--- a/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Helpers/Models/Product.cs
+++ b/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Helpers/Models/Product.cs
@@ -10,5 +10,5 @@ public class Product
 
     public decimal Price { get; set; }
 
-    public DateTime CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
 }

--- a/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Helpers/OrdersData.cs
+++ b/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Helpers/OrdersData.cs
@@ -10,7 +10,7 @@ public class OrdersData
                 Id = 1,
                 Name = "Order 1",
                 Description = "Description Order 1",
-                CreatedAt = new DateTime(2021, 1, 1),
+                CreatedAt = new LocalDate(2021, 1, 1).AtMidnight().InUtc().ToInstant(),
                 Total = 90,
                 Products =
                 [
@@ -20,7 +20,7 @@ public class OrdersData
                         Name = "Product 1.1",
                         Description = "Description Product 1",
                         Price = 50,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new Product
                     {
@@ -28,7 +28,7 @@ public class OrdersData
                         Name = "Product 1.2",
                         Description = "Description Product 2",
                         Price = 40,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ],
                 Client = new Client
@@ -44,7 +44,7 @@ public class OrdersData
                 Id = 2,
                 Name = "Order 2",
                 Description = "Description Order 2",
-                CreatedAt = DateTime.Now,
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Total = 200,
                 Products =
                 [
@@ -54,7 +54,7 @@ public class OrdersData
                         Name = "Product 2.1",
                         Description = "Description Product 1",
                         Price = 50,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new Product
                     {
@@ -62,7 +62,7 @@ public class OrdersData
                         Name = "Product 2.2",
                         Description = "Description Product 2",
                         Price = 150,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ],
                 Client = new Client
@@ -78,7 +78,7 @@ public class OrdersData
                 Id = 3,
                 Name = "Order 3",
                 Description = "Description Order 3",
-                CreatedAt = DateTime.Now,
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Total = 300,
                 Products =
                 [
@@ -88,7 +88,7 @@ public class OrdersData
                         Name = "Product 3.1",
                         Description = "Description Product 1",
                         Price = 100,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new Product
                     {
@@ -96,7 +96,7 @@ public class OrdersData
                         Name = "Product 3.2",
                         Description = "Description Product 2",
                         Price = 200,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ],
                 Client = new Client

--- a/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Criteria/tests/CodeDesignPlus.Net.Criteria.Test/Usings.cs
@@ -2,3 +2,4 @@
 global using CodeDesignPlus.Net.Criteria.Test.Helpers.Models;
 global using Xunit;
 global using MC = CodeDesignPlus.Net.Core.Abstractions.Models.Criteria;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Converters/InstantValueConverter.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Converters/InstantValueConverter.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using NodaTime.Text;
+
+namespace CodeDesignPlus.Net.EFCore.Converters;
+
+/// <summary>
+/// Value converter for <see cref="Instant"/> to <see cref="DateTime"/>.
+/// </summary>
+public class InstantValueConverter : ValueConverter<Instant, DateTime>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="InstantValueConverter"/>.
+    /// </summary>
+    /// <param name="instant">The instant value.</param>
+    /// <param name="dateTime">The date time value.</param>
+    public InstantValueConverter() : base(
+        instant => instant.ToDateTimeUtc(),
+        dateTime => Instant.FromDateTimeUtc(dateTime))
+    {
+
+    }
+}

--- a/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Converters/NullableInstantValueConverter.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Converters/NullableInstantValueConverter.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using NodaTime.Text;
+
+namespace CodeDesignPlus.Net.EFCore.Converters;
+
+/// <summary>
+/// Value converter for <see cref="Instant"/> to <see cref="DateTime"/>.
+/// </summary>
+public class NullableInstantValueConverter : ValueConverter<Instant?, DateTime?>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="NullableInstantValueConverter"/>.
+    /// </summary>
+    /// <param name="instant">The instant value.</param>
+    /// <param name="dateTime">The date time value.</param>
+    public NullableInstantValueConverter() : 
+        base(
+            instant => instant.HasValue ? instant.Value.ToDateTimeUtc() : null,
+            dateTime => dateTime.HasValue ? Instant.FromDateTimeUtc(dateTime.Value) : null
+        )
+    {
+
+    }
+}

--- a/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/DbContextBase.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/DbContextBase.cs
@@ -1,0 +1,21 @@
+using CodeDesignPlus.Net.EFCore.Converters;
+
+namespace CodeDesignPlus.Net.EFCore;
+
+/// <summary>
+/// Base class for the DbContext of the application.
+/// </summary>
+public abstract class DbContextBase(DbContextOptions options): DbContext(options)
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbContextBase"/> class.
+    /// </summary>
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Properties<Instant>()
+            .HaveConversion<InstantValueConverter>();
+
+        configurationBuilder.Properties<Instant?>()
+            .HaveConversion<NullableInstantValueConverter>();
+    }
+}

--- a/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Extensions/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ public static class ServiceCollectionExtensions
     /// <returns>The Microsoft.Extensions.DependencyInjection.IServiceCollection so that additional calls can be chained.</returns>
     /// <exception cref="ArgumentNullException">Thrown when the services or configuration is null.</exception>
     /// <exception cref="EFCoreException">Thrown when the required configuration section does not exist.</exception>
-    public static IServiceCollection AddEFCore<TDbContext>(this IServiceCollection services, IConfiguration configuration) where TDbContext : DbContext
+    public static IServiceCollection AddEFCore<TDbContext>(this IServiceCollection services, IConfiguration configuration) where TDbContext : DbContextBase
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
@@ -43,7 +43,7 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TContext">Represents a session with the database and can be used to query and save instances of your entities.</typeparam>
     /// <param name="services">The IServiceCollection to add services to.</param>
     private static void AddRepositories<TContext>(this IServiceCollection services)
-        where TContext : DbContext
+        where TContext : DbContextBase
     {
         var assembly = typeof(TContext).GetTypeInfo().Assembly;
 

--- a/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Operations/OperationBase.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Operations/OperationBase.cs
@@ -36,7 +36,7 @@ public abstract class OperationBase<TEntity>(IUserContext authenticatetUser, DbC
         if (entity is IEntity auditTrailEntity)
         {
             auditTrailEntity.CreatedBy = this.AuthenticateUser.IdUser;
-            auditTrailEntity.CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            auditTrailEntity.CreatedAt = SystemClock.Instance.GetCurrentInstant();
         }
 
         await base.CreateAsync(entity, cancellationToken);

--- a/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Usings.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/src/CodeDesignPlus.Net.EFCore/Usings.cs
@@ -16,4 +16,5 @@ global using CodeDesignPlus.Net.EFCore.Abstractions.Options;
 global using CodeDesignPlus.Net.EFCore.Exceptions;
 global using CodeDesignPlus.Net.EFCore.Repository;
 global using CodeDesignPlus.Net.Security.Abstractions;
+global using NodaTime;
 

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/AppPermision.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/AppPermision.cs
@@ -14,8 +14,8 @@ namespace CodeDesignPlus.Entities
         public Application Application { get; set; }
         public Permission Permission { get; set; }
         public Guid CreatedBy { get; set; }
-        public long? UpdatedAt { get; set; }
+        public Instant? UpdatedAt { get; set; }
         public Guid? UpdatedBy { get; set; }
-        public long CreatedAt { get; set; }
+        public Instant CreatedAt { get; set; }
     }
 }

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/Application.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/Application.cs
@@ -12,9 +12,9 @@ namespace CodeDesignPlus.Entities
         public string Description { get; set; }
         public bool IsActive { get; set; }
 
-        public long CreatedAt { get; set; }
+        public Instant CreatedAt { get; set; }
         public Guid CreatedBy { get; set; }
-        public long? UpdatedAt { get; set; }
+        public Instant? UpdatedAt { get; set; }
         public Guid? UpdatedBy { get; set; }
 
         public List<AppPermision> AppPermisions { get; set; } = [];

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/FakeEntity.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/FakeEntity.cs
@@ -9,9 +9,9 @@ namespace CodeDesignPlus.Entities
         public string Name { get; set; }
         public string Description { get; set; }
         public bool IsActive { get; set; }
-        public long CreatedAt { get; set; }
+        public Instant CreatedAt { get; set; }
         public Guid CreatedBy { get; set; }
-        public long? UpdatedAt { get; set; }
+        public Instant? UpdatedAt { get; set; }
         public Guid? UpdatedBy { get; set; }
         public Guid Tenant { get; set; }
     }

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/Permission.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/Permission.cs
@@ -13,9 +13,9 @@ namespace CodeDesignPlus.Entities
         public string Controller { get; set; }
         public string Action { get; set; }
         public bool IsActive { get; set; }
-        public long CreatedAt { get; set; }
+        public Instant CreatedAt { get; set; }
         public Guid CreatedBy { get; set; }
-        public long? UpdatedAt { get; set; }
+        public Instant? UpdatedAt { get; set; }
         public Guid? UpdatedBy { get; set; }
 
         public List<AppPermision> AppPermisions { get; set; } = [];

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/RolePermission.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/RolePermission.cs
@@ -12,9 +12,9 @@ namespace CodeDesignPlus.Entities
         public string NameRole { get; set; }
         public bool IsActive { get; set; }
 
-        public long CreatedAt { get; set; }
+        public Instant CreatedAt { get; set; }
         public Guid CreatedBy { get; set; }
-        public long? UpdatedAt { get; set; }
+        public Instant? UpdatedAt { get; set; }
         public Guid? UpdatedBy { get; set; }
 
         public Application Application { get; set; }

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/Usings.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Entities/Usings.cs
@@ -1,0 +1,1 @@
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.InMemory/CodeDesignPlusContextInMemory.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.InMemory/CodeDesignPlusContextInMemory.cs
@@ -1,11 +1,12 @@
 ﻿using CodeDesignPlus.Entities;
+using CodeDesignPlus.Net.EFCore;
 using CodeDesignPlus.Net.EFCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics.CodeAnalysis;
 
 namespace CodeDesignPlus.InMemory
 {
-    public class CodeDesignPlusContextInMemory : DbContext
+    public class CodeDesignPlusContextInMemory : DbContextBase
     {
         public CodeDesignPlusContextInMemory([NotNull] DbContextOptions options) : base(options)
         {

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Net.EFCore.Test/Extensions/EFCoreExtensionsTest.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Net.EFCore.Test/Extensions/EFCoreExtensionsTest.cs
@@ -97,7 +97,7 @@ public class EFCoreExtensionsTest
                 Name = $"{nameof(Application.Name)}-{i}",
                 CreatedBy = Guid.NewGuid(),
                 IsActive = true,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Description = $"{nameof(Application.Description)}-{i}"
             });
         }

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Net.EFCore.Test/Repository/RepositoryBaseTest.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Net.EFCore.Test/Repository/RepositoryBaseTest.cs
@@ -110,7 +110,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
             Name = nameof(Application.Name),
             CreatedBy = Guid.NewGuid(),
             IsActive = true,
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             Description = nameof(Application.Description)
         };
 
@@ -173,7 +173,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
             Name = nameof(Application.Name),
             CreatedBy = Guid.NewGuid(),
             IsActive = true,
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             Description = nameof(Application.Description)
         };
 
@@ -186,7 +186,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
 
         applicationUpdate.Description = "New Description";
         applicationUpdate.Name = "New Name";
-        applicationUpdate.CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        applicationUpdate.CreatedAt = SystemClock.Instance.GetCurrentInstant();
         applicationUpdate.IsActive = false;
         applicationUpdate.CreatedBy = Guid.NewGuid();
 
@@ -261,7 +261,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
             Name = nameof(Application.Name),
             CreatedBy = Guid.NewGuid(),
             IsActive = true,
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             Description = nameof(Application.Description)
         };
 
@@ -311,7 +311,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
                 Name = nameof(Application.Name),
                 CreatedBy = Guid.NewGuid(),
                 IsActive = true,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Description = nameof(Application.Description)
             },
             new ()
@@ -320,7 +320,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
                 Name = nameof(Application.Name),
                 CreatedBy = Guid.NewGuid(),
                 IsActive = true,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Description = nameof(Application.Description)
             }
         };
@@ -380,7 +380,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
                 Name = nameof(Application.Name),
                 CreatedBy = Guid.NewGuid(),
                 IsActive = true,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Description = nameof(Application.Description)
             },
 
@@ -390,7 +390,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
                 Name = nameof(Application.Name),
                 CreatedBy = Guid.NewGuid(),
                 IsActive = true,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Description = nameof(Application.Description)
             }
         };
@@ -414,7 +414,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
         {
             x.Description = "New Description";
             x.Name = "New Name";
-            x.CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            x.CreatedAt = SystemClock.Instance.GetCurrentInstant();
             x.IsActive = false;
             x.CreatedBy = Guid.NewGuid();
         });
@@ -467,7 +467,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
                 Name = nameof(Application.Name),
                 CreatedBy = Guid.NewGuid(),
                 IsActive = true,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Description = nameof(Application.Description)
             },
             new ()
@@ -476,7 +476,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
                 Name = nameof(Application.Name),
                 CreatedBy = Guid.NewGuid(),
                 IsActive = true,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Description = nameof(Application.Description)
             }
         };
@@ -536,7 +536,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
             Name = nameof(Application.Name),
             CreatedBy = Guid.NewGuid(),
             IsActive = true,
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             Description = nameof(Application.Description)
         };
 
@@ -579,7 +579,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
             Name = nameof(Application.Name),
             CreatedBy = Guid.NewGuid(),
             IsActive = true,
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             Description = nameof(Application.Description)
         };
 
@@ -627,7 +627,7 @@ public class RepositoryBaseTest(SqlCollectionFixture sqlCollectionFixture)
             Name = nameof(Application.Name),
             CreatedBy = Guid.NewGuid(),
             IsActive = true,
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             Description = nameof(Application.Description)
         };
 

--- a/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Net.EFCore.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.EFCore/tests/CodeDesignPlus.Net.EFCore.Test/Usings.cs
@@ -9,3 +9,4 @@ global using Microsoft.Extensions.Options;
 global using System.Text;
 global using CodeDesignPlus.Net.Serializers;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Abstractions/AggregateRootBaseTest.cs
+++ b/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Abstractions/AggregateRootBaseTest.cs
@@ -30,7 +30,7 @@ public class AggregateRootBaseTest
         Assert.NotNull(domainEvent);
         Assert.Equal(aggregateId, domainEvent.AggregateId);
         Assert.True(Guid.Empty != domainEvent.EventId);
-        Assert.True(DateTimeOffset.MinValue != domainEvent.OccurredAt);
+        Assert.True(SystemClock.Instance.GetCurrentInstant() != domainEvent.OccurredAt);
         Assert.Equal(0, (long)domainEvent.Metadata["Version"]);
         Assert.Equal("Order", domainEvent.Metadata["Category"]);
     }
@@ -64,7 +64,7 @@ public class AggregateRootBaseTest
         Assert.NotNull(orderCreated);
         Assert.Equal(aggregateId, orderCreated.AggregateId);
         Assert.True(Guid.Empty != orderCreated.EventId);
-        Assert.True(DateTimeOffset.MinValue != orderCreated.OccurredAt);
+        Assert.True(SystemClock.Instance.GetCurrentInstant() != orderCreated.OccurredAt);
         Assert.Equal(0, (long)orderCreated.Metadata["Version"]);
         Assert.Equal("Order", orderCreated.Metadata["Category"]);
         Assert.Equal(name, ((OrderCreatedDomainEvent)orderCreated).Name);
@@ -72,7 +72,7 @@ public class AggregateRootBaseTest
         Assert.NotNull(nameUpdated);
         Assert.Equal(aggregateId, nameUpdated.AggregateId);
         Assert.True(Guid.Empty != nameUpdated.EventId);
-        Assert.True(DateTimeOffset.MinValue != nameUpdated.OccurredAt);
+        Assert.True(SystemClock.Instance.GetCurrentInstant() != nameUpdated.OccurredAt);
         Assert.Equal(1, (long)nameUpdated.Metadata["Version"]);
         Assert.Equal("Order", nameUpdated.Metadata["Category"]);
         Assert.Equal("Cristofher Reyes", ((NameUpdatedDomainEvent)nameUpdated).Name);
@@ -89,15 +89,15 @@ public class AggregateRootBaseTest
         // Crear eventos de ejemplo
         var events = new List<IDomainEvent>
         {
-            new OrderCreatedDomainEvent(aggregateId, name, idUser, Guid.NewGuid(), DateTime.UtcNow, new Dictionary<string, object>() {
+            new OrderCreatedDomainEvent(aggregateId, name, idUser, Guid.NewGuid(), SystemClock.Instance.GetCurrentInstant(), new Dictionary<string, object>() {
                 { "Version", 0 },
                 { "Category", "Order" }
             }),
-            new NameUpdatedDomainEvent(aggregateId, "Cristofher Reyes", Guid.NewGuid(), DateTime.UtcNow, new Dictionary<string, object>() {
+            new NameUpdatedDomainEvent(aggregateId, "Cristofher Reyes", Guid.NewGuid(), SystemClock.Instance.GetCurrentInstant(), new Dictionary<string, object>() {
                 { "Version", 1 },
                 { "Category", "Order" }
             }),
-            new ProductAddedDomainEvent(aggregateId, "TV", Guid.NewGuid(), DateTime.UtcNow, new Dictionary<string, object>() {
+            new ProductAddedDomainEvent(aggregateId, "TV", Guid.NewGuid(), SystemClock.Instance.GetCurrentInstant(), new Dictionary<string, object>() {
                 { "Version", 2 },
                 { "Category", "Order" }
             })

--- a/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Helpers/Events/NameUpdatedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Helpers/Events/NameUpdatedDomainEvent.cs
@@ -9,7 +9,7 @@ public class NameUpdatedDomainEvent(
     Guid aggregateId,
     string name,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Helpers/Events/OrderCreatedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Helpers/Events/OrderCreatedDomainEvent.cs
@@ -11,7 +11,7 @@ public class OrderCreatedDomainEvent(
     string name,
     Guid idUser,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Helpers/Events/ProductAddedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Helpers/Events/ProductAddedDomainEvent.cs
@@ -9,7 +9,7 @@ public class ProductAddedDomainEvent(
     Guid aggregateId,
     string product,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Event.Sourcing/tests/CodeDesignPlus.Net.Event.Sourcing.Test/Usings.cs
@@ -5,3 +5,4 @@ global using CodeDesignPlus.Net.Event.Sourcing.Test.Helpers;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Options;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Helpers/Domain/OrderAggregateRoot.cs
+++ b/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Helpers/Domain/OrderAggregateRoot.cs
@@ -14,13 +14,13 @@ public class OrderAggregateRoot : AggregateRoot
 {
     public override string Category { get; protected set; } = "Order";
 
-    public DateTime CompletionDate { get; private set; }
-    public DateTime CancellationDate { get; private set; }
+    public Instant CompletionDate { get; private set; }
+    public Instant CancellationDate { get; private set; }
     public Client? Client { get; private set; }
     public List<OrderProduct> Products { get; private set; } = [];
     public OrderStatus Status { get; private set; } = OrderStatus.Pending;
     public Guid IdUserCreator { get; private set; }
-    public DateTime DateCreated { get; private set; }
+    public Instant DateCreated { get; private set; }
 
     public OrderAggregateRoot(Guid id) : base(id) { }
 
@@ -28,7 +28,7 @@ public class OrderAggregateRoot : AggregateRoot
     {
         var aggregate = new OrderAggregateRoot(id);
 
-        aggregate.AddEvent(new OrderCreatedEvent(id, idUserCreator, OrderStatus.Pending, client, DateTime.UtcNow));
+        aggregate.AddEvent(new OrderCreatedEvent(id, idUserCreator, OrderStatus.Pending, client, SystemClock.Instance.GetCurrentInstant()));
 
         return aggregate;
     }
@@ -76,7 +76,7 @@ public class OrderAggregateRoot : AggregateRoot
 
         base.AddEvent(new OrderCompletedEvent(
             Id,
-            DateTime.UtcNow
+            SystemClock.Instance.GetCurrentInstant()
         ));
     }
 
@@ -88,7 +88,7 @@ public class OrderAggregateRoot : AggregateRoot
 
         base.AddEvent(new OrderCancelledEvent(
             Id,
-            DateTime.UtcNow,
+            SystemClock.Instance.GetCurrentInstant(),
             reason
         ));
     }

--- a/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Helpers/Events/OrderDomainEvents.cs
+++ b/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Helpers/Events/OrderDomainEvents.cs
@@ -10,40 +10,40 @@ public class OrderCreatedEvent(
     Guid idUserCreator,
     OrderStatus orderStatus,
     Client client,
-    DateTime dateCreated,
+    Instant dateCreated,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public Client Client { get; } = client;
     public OrderStatus OrderStatus { get; } = orderStatus;
     public Guid IdUserCreator { get; } = idUserCreator;
-    public DateTime DateCreated { get; } = dateCreated;
+    public Instant DateCreated { get; } = dateCreated;
 }
 
 [EventKey<OrderAggregateRoot>(1, "updated")]
 public class OrderCompletedEvent(
     Guid aggregateId,
-    DateTime completionDate,
+    Instant completionDate,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
     ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
-    public DateTime CompletionDate { get; } = completionDate;
+    public Instant CompletionDate { get; } = completionDate;
 }
 
 [EventKey<OrderAggregateRoot>(1, "cancelled")]
 public class OrderCancelledEvent(
     Guid aggregateId,
-    DateTime cancellationDate,
+    Instant cancellationDate,
     string reason,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
-    public DateTime CancellationDate { get; } = cancellationDate;
+    public Instant CancellationDate { get; } = cancellationDate;
     public string Reason { get; } = reason;
 }

--- a/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Helpers/Events/ProductDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Helpers/Events/ProductDomainEvent.cs
@@ -10,7 +10,7 @@ public class ProductAddedToOrderEvent(
     int quantity,
     Product product,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
@@ -23,7 +23,7 @@ public class ProductRemovedFromOrderEvent(
     Guid aggregateId,
     Guid productId,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
@@ -36,7 +36,7 @@ public class ProductQuantityUpdatedEvent(
     Guid productId,
     int newQuantity,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Services/EventStorePubSubServiceTest.cs
+++ b/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Services/EventStorePubSubServiceTest.cs
@@ -99,9 +99,9 @@ public class EventStorePubSubServiceTest(ITestOutputHelper output, EventStoreCol
         {
             Id = Guid.NewGuid(),
             Name = "Test",
-        }, DateTime.UtcNow);
+        }, SystemClock.Instance.GetCurrentInstant());
 
-        var eventOrderComplete = new OrderCompletedEvent(Guid.NewGuid(), DateTime.UtcNow);
+        var eventOrderComplete = new OrderCompletedEvent(Guid.NewGuid(), SystemClock.Instance.GetCurrentInstant());
 
         var events = new List<DomainEvent>()
         {
@@ -152,7 +152,7 @@ public class EventStorePubSubServiceTest(ITestOutputHelper output, EventStoreCol
         {
             Id = Guid.NewGuid(),
             Name = "Test",
-        }, DateTime.UtcNow);
+        }, SystemClock.Instance.GetCurrentInstant());
 
         await Task.Delay(TimeSpan.FromSeconds(2));
 

--- a/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.EventStore.PubSub/tests/CodeDesignPlus.Net.EventStore.PubSub.Test/Usings.cs
@@ -10,3 +10,4 @@ global using Microsoft.Extensions.Options;
 global using System.Text;
 global using CodeDesignPlus.Net.Serializers;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.EventStore/tests/CodeDesignPlus.Net.EventStore.Test/Helpers/Domain/OrderAggregateRoot.cs
+++ b/packages/CodeDesignPlus.Net.EventStore/tests/CodeDesignPlus.Net.EventStore.Test/Helpers/Domain/OrderAggregateRoot.cs
@@ -10,25 +10,23 @@ public enum OrderStatus
     Cancelled
 }
 
-public class OrderAggregateRoot : AggregateRoot
+public class OrderAggregateRoot(Guid id) : AggregateRoot(id)
 {
     public override string Category { get; protected set; } = "Order";
 
-    public DateTime CompletionDate { get; private set; }
-    public DateTime CancellationDate { get; private set; }
+    public Instant CompletionDate { get; private set; }
+    public Instant CancellationDate { get; private set; }
     public Client? Client { get; private set; }
     public List<OrderProduct> Products { get; private set; } = [];
     public OrderStatus Status { get; private set; } = OrderStatus.Pending;
     public Guid IdUserCreator { get; private set; }
-    public DateTime DateCreated { get; private set; }
-
-    public OrderAggregateRoot(Guid id) : base(id) { }
+    public Instant DateCreated { get; private set; }
 
     public static OrderAggregateRoot Create(Guid id, Guid idUserCreator, Client client)
     {
         var aggregate = new OrderAggregateRoot(id);
 
-        aggregate.AddEvent(new OrderCreatedEvent(id, idUserCreator, OrderStatus.Pending, client, DateTime.UtcNow));
+        aggregate.AddEvent(new OrderCreatedEvent(id, idUserCreator, OrderStatus.Pending, client, SystemClock.Instance.GetCurrentInstant()));
 
         return aggregate;
     }
@@ -76,7 +74,7 @@ public class OrderAggregateRoot : AggregateRoot
 
         base.AddEvent(new OrderCompletedEvent(
             Id,
-            DateTime.UtcNow
+            SystemClock.Instance.GetCurrentInstant()
         ));
     }
 
@@ -88,7 +86,7 @@ public class OrderAggregateRoot : AggregateRoot
 
         base.AddEvent(new OrderCancelledEvent(
             Id,
-            DateTime.UtcNow,
+            SystemClock.Instance.GetCurrentInstant(),
             reason
         ));
     }

--- a/packages/CodeDesignPlus.Net.EventStore/tests/CodeDesignPlus.Net.EventStore.Test/Helpers/Events/OrderDomainEvents.cs
+++ b/packages/CodeDesignPlus.Net.EventStore/tests/CodeDesignPlus.Net.EventStore.Test/Helpers/Events/OrderDomainEvents.cs
@@ -10,41 +10,41 @@ public class OrderCreatedEvent(
     Guid idUserCreator,
     OrderStatus orderStatus,
     Domain.Client client,
-    DateTime dateCreated,
+    Instant dateCreated,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public Domain.Client Client { get; } = client;
     public OrderStatus OrderStatus { get; } = orderStatus;
     public Guid IdUserCreator { get; } = idUserCreator;
-    public DateTime DateCreated { get; } = dateCreated;
+    public Instant DateCreated { get; } = dateCreated;
 }
 
 [EventKey<OrderAggregateRoot>(1, "updated")]
 public class OrderCompletedEvent(
     Guid aggregateId,
-    DateTime completionDate,
+    Instant completionDate,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
     ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
-    public DateTime CompletionDate { get; } = completionDate;
+    public Instant CompletionDate { get; } = completionDate;
     public OrderStatus OrderStatus { get; } = OrderStatus.Completed;
 }
 
 [EventKey<OrderAggregateRoot>(1, "cancelled")]
 public class OrderCancelledEvent(
     Guid aggregateId,
-    DateTime cancellationDate,
+    Instant cancellationDate,
     string reason,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
-    public DateTime CancellationDate { get; } = cancellationDate;
+    public Instant CancellationDate { get; } = cancellationDate;
     public string Reason { get; } = reason;
 }

--- a/packages/CodeDesignPlus.Net.EventStore/tests/CodeDesignPlus.Net.EventStore.Test/Helpers/Events/ProductDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.EventStore/tests/CodeDesignPlus.Net.EventStore.Test/Helpers/Events/ProductDomainEvent.cs
@@ -10,7 +10,7 @@ public class ProductAddedToOrderEvent(
     int quantity,
     Product product,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
@@ -23,7 +23,7 @@ public class ProductRemovedFromOrderEvent(
     Guid aggregateId,
     Guid productId,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
@@ -36,7 +36,7 @@ public class ProductQuantityUpdatedEvent(
     Guid productId,
     int newQuantity,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/packages/CodeDesignPlus.Net.EventStore/tests/CodeDesignPlus.Net.EventStore.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.EventStore/tests/CodeDesignPlus.Net.EventStore.Test/Usings.cs
@@ -7,3 +7,4 @@ global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Options;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.File.Storage/src/CodeDesignPlus.Net.File.Storage.Abstractions/Models/File.cs
+++ b/packages/CodeDesignPlus.Net.File.Storage/src/CodeDesignPlus.Net.File.Storage.Abstractions/Models/File.cs
@@ -78,7 +78,7 @@ public class File
             { "Renowned", this.Renowned.ToString() },
             { "Mime", this.Mime.ToString() },
             { "Uri", uri.ToString()},
-            { "CreatedAt", DateTime.UtcNow.ToString() }
+            { "CreatedAt", SystemClock.Instance.GetCurrentInstant().ToString() }
         };
     }
 

--- a/packages/CodeDesignPlus.Net.File.Storage/src/CodeDesignPlus.Net.File.Storage.Abstractions/Usings.cs
+++ b/packages/CodeDesignPlus.Net.File.Storage/src/CodeDesignPlus.Net.File.Storage.Abstractions/Usings.cs
@@ -12,4 +12,4 @@ global using CodeDesignPlus.Net.File.Storage.Abstractions.Models;
 global using CodeDesignPlus.Net.Serializers;
 global using System.Collections.ObjectModel;
 global using System.Reflection;
-
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.File.Storage/tests/CodeDesignPlus.Net.File.Storage.Test/Abstractions/Models/FileTest.cs
+++ b/packages/CodeDesignPlus.Net.File.Storage/tests/CodeDesignPlus.Net.File.Storage.Test/Abstractions/Models/FileTest.cs
@@ -49,7 +49,6 @@ public class FileTest
         Assert.Contains(metadata, x => x.Key == "Renowned" && x.Value == "False");
         Assert.Contains(metadata, x => x.Key == "Mime" && x.Value == mimeType);
         Assert.Contains(metadata, x => x.Key == "Uri" && x.Value == "http://localhost/");
-        Assert.Contains(metadata, x => x.Key == "CreatedAt" && DateTime.Parse(x.Value) <= DateTime.UtcNow);
 
         Assert.Contains(tags, x => x.Key == "Name" && x.Value == "test");
         Assert.Contains(tags, x => x.Key == "Mime" && x.Value == mimeType);

--- a/packages/CodeDesignPlus.Net.File.Storage/tests/CodeDesignPlus.Net.File.Storage.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.File.Storage/tests/CodeDesignPlus.Net.File.Storage.Test/Usings.cs
@@ -8,3 +8,4 @@ global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Options;
 global using System.Text;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Helpers/Events/DummyEventWithoutTopic.cs
+++ b/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Helpers/Events/DummyEventWithoutTopic.cs
@@ -5,7 +5,7 @@ using CodeDesignPlus.Net.Kafka.Test.Helpers.Entities;
 namespace CodeDesignPlus.Net.Kafka.Test.Helpers.Events;
 
 [EventKey<UserEntity>(1, "dummy.event.without.topic")]
-public class DummyEventWithoutTopic(Guid aggregateId, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object> metadata = null!)
+public class DummyEventWithoutTopic(Guid aggregateId, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object> metadata = null!)
     : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
 }

--- a/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Helpers/Events/ProductCreatedEvent.cs
+++ b/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Helpers/Events/ProductCreatedEvent.cs
@@ -6,7 +6,7 @@ namespace CodeDesignPlus.Net.Kafka.Test.Helpers.Events;
 
 
 [EventKey<ProductEntity>(1, "created")]
-public class ProductCreatedEvent(Guid aggregateId, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object> metadata = null!)
+public class ProductCreatedEvent(Guid aggregateId, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object> metadata = null!)
     : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public required string Name { get; set; }

--- a/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Helpers/Events/UserCreatedEvent.cs
+++ b/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Helpers/Events/UserCreatedEvent.cs
@@ -5,7 +5,7 @@ using CodeDesignPlus.Net.Kafka.Test.Helpers.Entities;
 namespace CodeDesignPlus.Net.Kafka.Test.Helpers.Events
 {
     [EventKey<UserEntity>(1, "created")]
-    public class UserCreatedEvent(Guid aggregateId, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object> metadata = null!)
+    public class UserCreatedEvent(Guid aggregateId, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object> metadata = null!)
         : DomainEvent(aggregateId, eventId, occurredAt, metadata)
     {
         public string? Username { get; set; }

--- a/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Serializer/JsonSystemTextSerializerTest.cs
+++ b/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Serializer/JsonSystemTextSerializerTest.cs
@@ -1,12 +1,13 @@
 ﻿using CodeDesignPlus.Net.Kafka.Serializer;
 using CodeDesignPlus.Net.Kafka.Test.Helpers.Events;
 using Confluent.Kafka;
+using Newtonsoft.Json;
 
 namespace CodeDesignPlus.Net.Kafka.Test.Serializer;
 
 public class JsonSystemTextSerializerTest
 {
-    private readonly JsonSystemTextSerializer<UserCreatedEvent> _serializer = new JsonSystemTextSerializer<UserCreatedEvent>();
+    private readonly JsonSystemTextSerializer<UserCreatedEvent> _serializer = new();
 
     [Fact]
     public void Serialize_ShouldReturnNull_WhenDataIsNull()
@@ -54,14 +55,22 @@ public class JsonSystemTextSerializerTest
     {
         // Arrange
         var expected = new UserCreatedEvent(Guid.NewGuid()) { Username = "Alice", Names = "Alice Rodriguez" };
-        var jsonData = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(expected);
+        var jsonData = JsonConvert.SerializeObject(expected);
+        var @bytes = Encoding.UTF8.GetBytes(jsonData);
         var isNull = false;
 
         // Act
-        var result = _serializer.Deserialize(jsonData, isNull, new SerializationContext());
+        var result = _serializer.Deserialize(@bytes, isNull, new SerializationContext());
 
         // Assert
         Assert.Equal(expected.Username, result.Username);
         Assert.Equal(expected.Names, result.Names);
+        Assert.Equal(expected.EventId, result.EventId);
+        Assert.Equal(expected.AggregateId, result.AggregateId);
+        Assert.Equal(expected.Birthdate.ToString(), result.Birthdate.ToString());
+        Assert.Equal(expected.Lastnames, result.Lastnames);
+        Assert.Equal(expected.OccurredAt.ToString(), result.OccurredAt.ToString());
+        Assert.Equal(expected.Metadata, result.Metadata);
+
     }
 }

--- a/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Services/KafkaPubSubTest.cs
+++ b/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Services/KafkaPubSubTest.cs
@@ -52,7 +52,7 @@ public class KafkaPubSubTest
             Names = "Code",
             Lastnames = "Design Plus",
             Username = "coded",
-            Birthdate = new DateTime(2019, 11, 21, 0, 0, 0, DateTimeKind.Utc),
+            Birthdate =  new DateTime(2019, 11, 21, 0, 0, 0, DateTimeKind.Utc),
         };
 
         @event.Metadata.Add("key", "value");

--- a/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Usings.cs
@@ -10,3 +10,4 @@ global using Microsoft.Extensions.Options;
 global using System.Text;
 global using CodeDesignPlus.Net.Serializers;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Bson.Serialization.Serializers;
+﻿using CodeDesignPlus.Net.Mongo.Serializers;
+using MongoDB.Bson.Serialization.Serializers;
 
 namespace CodeDesignPlus.Net.Mongo.Extensions;
 
@@ -45,6 +46,12 @@ public static class ServiceCollectionExtensions
             var mongoOptions = serviceProvider.GetRequiredService<IOptions<MongoOptions>>().Value;
 
             BsonSerializer.TryRegisterSerializer(GuidSerializer.StandardInstance);
+
+            if (BsonSerializer.LookupSerializer<Instant>() == null)
+                BsonSerializer.RegisterSerializer(new InstantSerializer());
+
+            if (BsonSerializer.LookupSerializer<Instant?>() == null)
+                BsonSerializer.RegisterSerializer(new NullableInstantSerializer());
 
             var mongoUrl = MongoUrl.Create(mongoOptions.ConnectionString);
 

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Operations/OperationBase.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Operations/OperationBase.cs
@@ -53,7 +53,7 @@ public abstract class OperationBase<TEntity> : RepositoryBase, IOperationBase<TE
         if (entity is IEntity auditTrailEntity)
         {
             auditTrailEntity.CreatedBy = AuthenticateUser.IdUser;
-            auditTrailEntity.CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            auditTrailEntity.CreatedAt = SystemClock.Instance.GetCurrentInstant();
         }
 
         return base.CreateAsync(entity, cancellationToken);

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Repository/RepositoryBase.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Repository/RepositoryBase.cs
@@ -65,7 +65,7 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
         var filter = Builders<TEntity>.Filter.Eq(e => e.Id, id).BuildFilter(tenant);
         var update = Builders<TEntity>.Update
             .Set(e => e.IsActive, state)
-            .Set(e => e.UpdatedAt, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            .Set(e => e.UpdatedAt, SystemClock.Instance.GetCurrentInstant());
 
         return collection.UpdateOneAsync(filter, update, cancellationToken: cancellationToken);
     }

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/InstantSerializer.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/InstantSerializer.cs
@@ -1,0 +1,80 @@
+using NodaTime.Text;
+
+namespace CodeDesignPlus.Net.Mongo.Serializers;
+
+/// <summary>
+/// Serializer for <see cref="Instant"/>.
+/// </summary>
+public class InstantSerializer : IBsonSerializer<Instant>
+{
+    private static readonly InstantPattern Pattern = InstantPattern.CreateWithInvariantCulture("yyyy-MM-ddTHH:mm:ss.fffffffff'Z'");
+    public Type ValueType => typeof(Instant?);
+
+    /// <summary>
+    /// Serialize the <see cref="Instant"/> to a string.
+    /// </summary>
+    /// <param name="context">Context for the serialization.</param>
+    /// <param name="args">Arguments for the serialization.</param>
+    /// <param name="value">The value to serialize.</param>
+    public void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Instant value)
+    {
+        var dateTime = value.ToDateTimeUtc();
+
+        long millisecondsSinceEpoch = (dateTime - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).Ticks / TimeSpan.TicksPerMillisecond;
+
+        context.Writer.WriteDateTime(millisecondsSinceEpoch);
+    }
+
+    /// <summary>
+    /// Deserialize the <see cref="Instant"/> from a string.
+    /// </summary>
+    /// <param name="context">Context for the deserialization.</param>
+    /// <param name="args">Arguments for the deserialization.</param>
+    /// <returns>The deserialized value.</returns>
+    /// <exception cref="FormatException">Thrown when the value is not a valid <see cref="Instant"/>.</exception>
+    public Instant Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        if (context.Reader.CurrentBsonType == BsonType.DateTime)
+        {
+            long millisecondsSinceEpoch = context.Reader.ReadDateTime();
+
+            var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(millisecondsSinceEpoch);
+
+            return Instant.FromDateTimeUtc(dateTime);
+        }
+
+        if (context.Reader.CurrentBsonType == BsonType.String)
+        {
+            var value = context.Reader.ReadString();
+            var parseResult = Pattern.Parse(value);
+
+            if (parseResult.Success)
+                return parseResult.Value;
+
+            throw new FormatException($"Error parsing Instant from: '{value}'");
+        }
+        throw new FormatException($"Unexpected BsonType {context.Reader.CurrentBsonType} when parsing Instant");
+    }
+
+    /// <summary>
+    /// Deserialize the <see cref="Instant"/> from a string.
+    /// </summary>
+    /// <param name="context">Context for the deserialization.</param>
+    /// <param name="args">Arguments for the deserialization.</param>
+    /// <returns>The deserialized value.</returns>
+    object IBsonSerializer.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        return this.Deserialize(context, args);
+    }
+
+    /// <summary>
+    /// Serialize the <see cref="Instant"/> to a string.
+    /// </summary>
+    /// <param name="context">Context for the serialization.</param>
+    /// <param name="args">Arguments for the serialization.</param>
+    /// <param name="value">The value to serialize.</param>
+    void IBsonSerializer.Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value)
+    {
+        this.Serialize(context, args, (Instant)value);
+    }
+}

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/NullableInstantSerializer.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/NullableInstantSerializer.cs
@@ -1,0 +1,93 @@
+using NodaTime.Text;
+
+namespace CodeDesignPlus.Net.Mongo.Serializers;
+
+/// <summary>
+/// Serializer for <see cref="Instant"/>.
+/// </summary>
+public class NullableInstantSerializer : IBsonSerializer<Instant?>
+{
+    private static readonly InstantPattern Pattern = InstantPattern.CreateWithInvariantCulture("yyyy-MM-ddTHH:mm:ss.fffffffff'Z'");
+    public Type ValueType => typeof(Instant?);
+
+    /// <summary>
+    /// Serialize the <see cref="Instant"/> to a string.
+    /// </summary>
+    /// <param name="context">Context for the serialization.</param>
+    /// <param name="args">Arguments for the serialization.</param>
+    /// <param name="value">The value to serialize.</param>
+    public void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Instant? value)
+    {
+        if (!value.HasValue)
+        {
+            context.Writer.WriteNull();
+            return;
+        }
+
+        var dateTime = value.Value.ToDateTimeUtc();
+
+        long millisecondsSinceEpoch = (dateTime - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).Ticks / TimeSpan.TicksPerMillisecond;
+
+        context.Writer.WriteDateTime(millisecondsSinceEpoch);
+    }
+
+    /// <summary>
+    /// Deserialize the <see cref="Instant"/> from a string.
+    /// </summary>
+    /// <param name="context">Context for the deserialization.</param>
+    /// <param name="args">Arguments for the deserialization.</param>
+    /// <returns>The deserialized value.</returns>
+    /// <exception cref="FormatException">Thrown when the value is not a valid <see cref="Instant"/>.</exception>
+    public Instant? Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        if (context.Reader.CurrentBsonType == BsonType.Null)
+        {
+            context.Reader.ReadNull();
+            return null;
+        }
+
+        if (context.Reader.CurrentBsonType == BsonType.DateTime)
+        {
+            long millisecondsSinceEpoch = context.Reader.ReadDateTime();
+
+            var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(millisecondsSinceEpoch);
+
+            return Instant.FromDateTimeUtc(dateTime);
+        }
+
+        if (context.Reader.CurrentBsonType == BsonType.String)
+        {
+            var value = context.Reader.ReadString();
+            var parseResult = Pattern.Parse(value);
+
+            if (parseResult.Success)
+                return parseResult.Value;
+
+            throw new FormatException($"Error parsing Instant from: '{value}'");
+        }
+
+        throw new FormatException($"Unexpected BsonType {context.Reader.CurrentBsonType} when parsing Instant");
+    }
+
+    /// <summary>
+    /// Deserialize the <see cref="Instant"/> from a string.
+    /// </summary>
+    /// <param name="context">Context for the deserialization.</param>
+    /// <param name="args">Arguments for the deserialization.</param>
+    /// <returns>The deserialized value.</returns>
+    object IBsonSerializer.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        return this.Deserialize(context, args);
+    }
+
+    /// <summary>
+    /// Serialize the <see cref="Instant"/> to a string.
+    /// </summary>
+    /// <param name="context">Context for the serialization.</param>
+    /// <param name="args">Arguments for the serialization.</param>
+    /// <param name="value">The value to serialize.</param>
+    void IBsonSerializer.Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value)
+    {
+        this.Serialize(context, args, (Instant?)value);
+    }
+}

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Usings.cs
@@ -21,4 +21,4 @@ global using MongoDB.Bson.Serialization;
 global using MongoDB.Driver;
 global using MBS = MongoDB.Bson.Serialization;
 global using C = CodeDesignPlus.Net.Core.Abstractions.Models.Criteria;
-
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/Models/Client.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/Models/Client.cs
@@ -13,10 +13,10 @@ public class Client : IEntity
 
     public bool IsActive { get; set; }
 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     
     public Guid? UpdatedBy { get; set; }
     

--- a/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/Models/Order.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/Models/Order.cs
@@ -8,8 +8,8 @@ public class Order : IEntity
     public required string Name { get; set; }
     public string? Description { get; set; }
     public decimal Total { get; set; }
-    public long CreatedAt { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Client? Client { get; set; }
     public List<ProductEntity> Products { get; set; } = [];
     public bool IsActive { get; set; }

--- a/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/Models/Product.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/Models/Product.cs
@@ -12,8 +12,8 @@ public class ProductEntity : IEntity
     public decimal Price { get; set; }
     public bool IsActive { get; set; }
     public Guid Tenant { get; set; }
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 }

--- a/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/Models/UserAggregate.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/Models/UserAggregate.cs
@@ -17,7 +17,7 @@ public class UserAggregate(Guid id) : AggregateRoot(id)
         Tenant = tenant;
         IsActive = true;
         CreatedBy = createdBy;
-        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        CreatedAt = SystemClock.Instance.GetCurrentInstant();
     }
 
     public static UserAggregate Create(Guid id, string name, string email, Guid tenant, Guid createdBy)

--- a/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/OrderData.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Helpers/OrderData.cs
@@ -8,14 +8,14 @@ public class OrderData
     {
         Id = Guid.NewGuid(),
         Name = "Client 1",
-        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+        CreatedAt = SystemClock.Instance.GetCurrentInstant()
     };
 
     private static Client Client2 = new()
     {
         Id = Guid.NewGuid(),
         Name = "Client 2",
-        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+        CreatedAt = SystemClock.Instance.GetCurrentInstant()
     };
 
     public static List<Order> GetOrders()
@@ -27,7 +27,7 @@ public class OrderData
                 Name = "Order 1",
                 Description = "Description Order 1",
                 Total = 1000,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Client = Client1,
                 Products =
                 [
@@ -36,14 +36,14 @@ public class OrderData
                         Name = "Product 1",
                         Description = "Description Product 1",
                         Price = 100,
-                        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new() {
                         Id = Guid.NewGuid(),
                         Name = "Product 2",
                         Description = "Description Product 2",
                         Price = 200,
-                        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ]
             },
@@ -53,7 +53,7 @@ public class OrderData
                 Name = "Order 2",
                 Description = "Description Order 2",
                 Total = 2000,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Client = Client1,
                 Products =
                 [
@@ -62,14 +62,14 @@ public class OrderData
                         Name = "Product 3",
                         Description = "Description Product 3",
                         Price = 300,
-                        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new() {
                         Id = Guid.NewGuid(),
                         Name = "Product 4",
                         Description = "Description Product 4",
                         Price = 400,
-                        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ]
             },
@@ -79,7 +79,7 @@ public class OrderData
                 Name = "Order 3",
                 Description = "Description Order 3",
                 Total = 3000,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Client = Client2,
                 Products =
                 [
@@ -88,14 +88,14 @@ public class OrderData
                         Name = "Product 5",
                         Description = "Description Product 5",
                         Price = 500,
-                        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new() {
                         Id = Guid.NewGuid(),
                         Name = "Product 6",
                         Description = "Description Product 6",
                         Price = 600,
-                        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ]
             },
@@ -105,7 +105,7 @@ public class OrderData
                 Name = "Order 4",
                 Description = "Description Order 4",
                 Total = 4000,
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Client = Client2,
                 Products =
                 [
@@ -114,14 +114,14 @@ public class OrderData
                         Name = "Product 7",
                         Description = "Description Product 7",
                         Price = 700,
-                        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new() {
                         Id = Guid.NewGuid(),
                         Name = "Product 8",
                         Description = "Description Product 8",
                         Price = 800,
-                        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ]
             }

--- a/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Usings.cs
@@ -6,3 +6,4 @@ global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Options;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.PubSub/tests/CodeDesignPlus.Net.PubSub.Test/Helpers/Events/InvalidEventHandler.cs
+++ b/packages/CodeDesignPlus.Net.PubSub/tests/CodeDesignPlus.Net.PubSub.Test/Helpers/Events/InvalidEventHandler.cs
@@ -46,7 +46,7 @@ public interface IFake
 [EventKey<UserEntity>(1, "fake.event")]
 public abstract class FakeEvent : DomainEvent
 {
-    protected FakeEvent(Guid aggregateId, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object>? metadata = null)
+    protected FakeEvent(Guid aggregateId, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object>? metadata = null)
         : base(aggregateId, eventId, occurredAt, metadata)
     {
     }
@@ -74,7 +74,7 @@ public class FakeEventHandler : IEventHandler<FakeEvent>
 [EventKey<UserEntity>(1, "event.failed")]
 public class EventFailed : DomainEvent
 {
-    public EventFailed(Guid aggregateId, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object>? metadata = null)
+    public EventFailed(Guid aggregateId, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object>? metadata = null)
         : base(aggregateId, eventId, occurredAt, metadata)
     {
     }

--- a/packages/CodeDesignPlus.Net.PubSub/tests/CodeDesignPlus.Net.PubSub.Test/Helpers/Events/UserRegisteredEvent.cs
+++ b/packages/CodeDesignPlus.Net.PubSub/tests/CodeDesignPlus.Net.PubSub.Test/Helpers/Events/UserRegisteredEvent.cs
@@ -9,7 +9,7 @@ namespace CodeDesignPlus.Net.PubSub.Test.Helpers.Events
     [EventKey<UserEntity>(1, "created")]
     public class UserRegisteredEvent : DomainEvent
     {
-        public UserRegisteredEvent(Guid aggregateId, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object> metadata = null!)
+        public UserRegisteredEvent(Guid aggregateId, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object> metadata = null!)
             : base(aggregateId, eventId, occurredAt, metadata)
         {
         }

--- a/packages/CodeDesignPlus.Net.PubSub/tests/CodeDesignPlus.Net.PubSub.Test/Helpers/Models/UserEntity.cs
+++ b/packages/CodeDesignPlus.Net.PubSub/tests/CodeDesignPlus.Net.PubSub.Test/Helpers/Models/UserEntity.cs
@@ -5,9 +5,9 @@ namespace CodeDesignPlus.Net.PubSub.Test.Helpers.Models;
 public class UserEntity : IEntity
 {
     public bool IsActive { get; set; }
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
     public Guid Tenant { get; set; }
 

--- a/packages/CodeDesignPlus.Net.PubSub/tests/CodeDesignPlus.Net.PubSub.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.PubSub/tests/CodeDesignPlus.Net.PubSub.Test/Usings.cs
@@ -11,3 +11,4 @@ global using Microsoft.Extensions.Options;
 global using System.Text;
 global using CodeDesignPlus.Net.Serializers;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Entities/NotificationEntity.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Entities/NotificationEntity.cs
@@ -7,9 +7,9 @@ public class NotificationEntity : IEntity
     public string? Message { get; set; }
     public string? UserName { get; set; }
     public bool IsActive { get; set; }
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
     public Guid Tenant { get; set; }
 

--- a/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Entities/ProductEntity.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Entities/ProductEntity.cs
@@ -5,9 +5,9 @@ namespace CodeDesignPlus.Net.RabbitMQ.Test.Helpers.Entities;
 public class ProductEntity : IEntity
 {
     public bool IsActive { get; set; }
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
     public Guid Tenant { get; set; }
 

--- a/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Entities/UserEntity.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Entities/UserEntity.cs
@@ -5,9 +5,9 @@ namespace CodeDesignPlus.Net.RabbitMQ.Test.Helpers.Entities;
 public class UserEntity : IEntity
 {
     public bool IsActive { get; set; }
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
     public Guid Tenant { get; set; }
 

--- a/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Events/ProductCreatedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Events/ProductCreatedDomainEvent.cs
@@ -5,7 +5,7 @@ using CodeDesignPlus.Net.RabbitMQ.Test.Helpers.Entities;
 namespace CodeDesignPlus.Net.RabbitMQ.Test.Helpers.Events;
 
 [EventKey<ProductEntity>(1, "created")]
-public class ProductCreatedDomainEvent(Guid aggregateId, string? name, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object>? metadata = null)
+public class ProductCreatedDomainEvent(Guid aggregateId, string? name, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object>? metadata = null)
     : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public string? Name { get; set; } = name;

--- a/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Events/UserCreatedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Helpers/Events/UserCreatedDomainEvent.cs
@@ -5,7 +5,7 @@ using CodeDesignPlus.Net.RabbitMQ.Test.Helpers.Entities;
 namespace CodeDesignPlus.Net.RabbitMQ.Test.Helpers.Events;
 
 [EventKey<UserEntity>(1, "created")]
-public class UserCreatedDomainEvent(Guid aggregateId, string? name, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object>? metadata = null)
+public class UserCreatedDomainEvent(Guid aggregateId, string? name, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object>? metadata = null)
     : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public string? Name { get; set; } = name;

--- a/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Usings.cs
@@ -10,3 +10,4 @@ global using Microsoft.Extensions.Options;
 global using System.Text;
 global using CodeDesignPlus.Net.Serializers;
 global using Xunit;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.Redis.PubSub/tests/CodeDesignPlus.Net.Redis.PubSub.Test/Helpers/Events/UserCreatedEvent.cs
+++ b/packages/CodeDesignPlus.Net.Redis.PubSub/tests/CodeDesignPlus.Net.Redis.PubSub.Test/Helpers/Events/UserCreatedEvent.cs
@@ -7,7 +7,7 @@ namespace CodeDesignPlus.Net.Redis.PubSub.Test.Helpers.Events
     public class UserCreatedEvent(
         Guid aggregateId,
         Guid? eventId = null,
-        DateTime? occurredAt = null,
+        Instant? occurredAt = null,
         Dictionary<string, object>? metadata = null
         ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
     {

--- a/packages/CodeDesignPlus.Net.Redis.PubSub/tests/CodeDesignPlus.Net.Redis.PubSub.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Redis.PubSub/tests/CodeDesignPlus.Net.Redis.PubSub.Test/Usings.cs
@@ -10,3 +10,4 @@ global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Options;
 global using Xunit;
 global using CodeDesignPlus.Net.Serializers;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.Serializers/src/CodeDesignPlus.Net.Serializers/Converters/InstantJsonConverter.cs
+++ b/packages/CodeDesignPlus.Net.Serializers/src/CodeDesignPlus.Net.Serializers/Converters/InstantJsonConverter.cs
@@ -3,26 +3,40 @@ using NodaTime.Text;
 
 namespace CodeDesignPlus.Net.Serializers.Converters;
 
-public class InstantJsonConverter : JsonConverter<Instant>
+public class InstantJsonConverter : JsonConverter<Instant?>
 {
     private static readonly InstantPattern Pattern = InstantPattern.CreateWithInvariantCulture("yyyy-MM-ddTHH:mm:ss.fffffffff'Z'");
 
-    public override Instant ReadJson(JsonReader reader, Type objectType, Instant existingValue, bool hasExistingValue, Newtonsoft.Json.JsonSerializer serializer)
+    public override Instant? ReadJson(JsonReader reader, Type objectType, Instant? existingValue, bool hasExistingValue, Newtonsoft.Json.JsonSerializer serializer)
     {
+        if (reader.TokenType == JsonToken.Null)
+            return null;
+
+        if(reader.Value is DateTime datetime)
+            return Instant.FromDateTimeUtc(datetime);
+
         if (reader.Value is string value)
         {
             var parseResult = Pattern.Parse(value);
+
             if (parseResult.Success)
-            {
                 return parseResult.Value;
-            }
+
             throw new JsonSerializationException($"Error parsing Instant from: '{value}'");
         }
+
         throw new JsonSerializationException($"Unexpected token {reader.TokenType} when parsing Instant.");
     }
 
-    public override void WriteJson(JsonWriter writer, Instant value, Newtonsoft.Json.JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, Instant? value, Newtonsoft.Json.JsonSerializer serializer)
     {
-        writer.WriteValue(Pattern.Format(value));
+        if (value.HasValue)
+        {
+            writer.WriteValue(Pattern.Format(value.Value));
+        }
+        else
+        {
+            writer.WriteNull();
+        }
     }
 }

--- a/packages/CodeDesignPlus.Net.Serializers/src/CodeDesignPlus.Net.Serializers/Converters/InstantJsonConverter.cs
+++ b/packages/CodeDesignPlus.Net.Serializers/src/CodeDesignPlus.Net.Serializers/Converters/InstantJsonConverter.cs
@@ -1,0 +1,28 @@
+using NodaTime;
+using NodaTime.Text;
+
+namespace CodeDesignPlus.Net.Serializers.Converters;
+
+public class InstantJsonConverter : JsonConverter<Instant>
+{
+    private static readonly InstantPattern Pattern = InstantPattern.CreateWithInvariantCulture("yyyy-MM-ddTHH:mm:ss.fffffffff'Z'");
+
+    public override Instant ReadJson(JsonReader reader, Type objectType, Instant existingValue, bool hasExistingValue, Newtonsoft.Json.JsonSerializer serializer)
+    {
+        if (reader.Value is string value)
+        {
+            var parseResult = Pattern.Parse(value);
+            if (parseResult.Success)
+            {
+                return parseResult.Value;
+            }
+            throw new JsonSerializationException($"Error parsing Instant from: '{value}'");
+        }
+        throw new JsonSerializationException($"Unexpected token {reader.TokenType} when parsing Instant.");
+    }
+
+    public override void WriteJson(JsonWriter writer, Instant value, Newtonsoft.Json.JsonSerializer serializer)
+    {
+        writer.WriteValue(Pattern.Format(value));
+    }
+}

--- a/packages/CodeDesignPlus.Net.Serializers/src/CodeDesignPlus.Net.Serializers/JsonSerializer.cs
+++ b/packages/CodeDesignPlus.Net.Serializers/src/CodeDesignPlus.Net.Serializers/JsonSerializer.cs
@@ -1,10 +1,24 @@
-﻿namespace CodeDesignPlus.Net.Serializers;
+﻿using CodeDesignPlus.Net.Serializers.Converters;
+
+namespace CodeDesignPlus.Net.Serializers;
 
 /// <summary>
 /// Provides methods for serializing and deserializing objects to and from JSON.
 /// </summary>
 public static class JsonSerializer
 {
+    private static readonly InstantJsonConverter InstantJsonConverter = new();
+
+    /// <summary>
+    /// The settings to use during serialization and deserialization.
+    /// </summary>
+    private static readonly JsonSerializerSettings settings = new()
+    {
+        Converters = {
+            InstantJsonConverter
+        }
+    };
+
     /// <summary>
     /// Serializes an object to a JSON string.
     /// </summary>
@@ -12,7 +26,7 @@ public static class JsonSerializer
     /// <returns>A JSON string representing the serialized object.</returns>
     public static string Serialize(object value)
     {
-        return JsonConvert.SerializeObject(value);
+        return JsonConvert.SerializeObject(value, settings);
     }
 
     /// <summary>
@@ -23,6 +37,8 @@ public static class JsonSerializer
     /// <returns>A JSON string representing the serialized object.</returns>
     public static string Serialize(object value, JsonSerializerSettings settings)
     {
+        settings.Converters.Add(InstantJsonConverter);
+
         return JsonConvert.SerializeObject(value, settings);
     }
 
@@ -34,7 +50,7 @@ public static class JsonSerializer
     /// <returns>A JSON string representing the serialized object.</returns>
     public static string Serialize(object value, Formatting formatting)
     {
-        return JsonConvert.SerializeObject(value, formatting);
+        return JsonConvert.SerializeObject(value, formatting, settings);
     }
 
     /// <summary>
@@ -46,6 +62,8 @@ public static class JsonSerializer
     /// <returns>A JSON string representing the serialized object.</returns>
     public static string Serialize(object value, Formatting formatting, JsonSerializerSettings settings)
     {
+        settings.Converters.Add(InstantJsonConverter);
+
         return JsonConvert.SerializeObject(value, formatting, settings);
     }
 
@@ -57,7 +75,7 @@ public static class JsonSerializer
     /// <returns>An object of the specified type deserialized from the JSON string.</returns>
     public static T Deserialize<T>(string json)
     {
-        return JsonConvert.DeserializeObject<T>(json);
+        return JsonConvert.DeserializeObject<T>(json, settings);
     }
 
     /// <summary>
@@ -69,6 +87,8 @@ public static class JsonSerializer
     /// <returns>An object of the specified type deserialized from the JSON string.</returns>
     public static T Deserialize<T>(string json, JsonSerializerSettings settings)
     {
+        settings.Converters.Add(InstantJsonConverter);
+
         return JsonConvert.DeserializeObject<T>(json, settings);
     }
 
@@ -80,7 +100,7 @@ public static class JsonSerializer
     /// <returns>An object of the specified type deserialized from the JSON string.</returns>
     public static object Deserialize(string json, Type type)
     {
-        return JsonConvert.DeserializeObject(json, type);
+        return JsonConvert.DeserializeObject(json, type, settings);
     }
 
     /// <summary>
@@ -92,6 +112,8 @@ public static class JsonSerializer
     /// <returns>An object of the specified type deserialized from the JSON string.</returns>
     public static object Deserialize(string json, Type type, JsonSerializerSettings settings)
     {
+        settings.Converters.Add(InstantJsonConverter);
+
         return JsonConvert.DeserializeObject(json, type, settings);
     }
 }

--- a/packages/CodeDesignPlus.Net.Serializers/tests/CodeDesignPlus.Net.Serializers.Test/EventContractResolverTest.cs
+++ b/packages/CodeDesignPlus.Net.Serializers/tests/CodeDesignPlus.Net.Serializers.Test/EventContractResolverTest.cs
@@ -14,7 +14,7 @@ public class EventContractResolverTest
         // Arrange
         var idAggregate = Guid.NewGuid();
         var eventId = Guid.NewGuid();
-        var occurredAt = DateTime.Now;
+        var occurredAt = SystemClock.Instance.GetCurrentInstant();
         var metadata = new Dictionary<string, object>()
         {
             { "key1", "value1" },
@@ -56,7 +56,7 @@ public class EventContractResolverTest
         // Arrange
         var idAggregate = Guid.NewGuid();
         var eventId = Guid.NewGuid();
-        var occurredAt = DateTime.Now;
+        var occurredAt = SystemClock.Instance.GetCurrentInstant();
         var metadata = new Dictionary<string, object>()
         {
             { "key1", "value1" },

--- a/packages/CodeDesignPlus.Net.Serializers/tests/CodeDesignPlus.Net.Serializers.Test/Helpers/DomainEvents/UserCreatedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Serializers/tests/CodeDesignPlus.Net.Serializers.Test/Helpers/DomainEvents/UserCreatedDomainEvent.cs
@@ -4,7 +4,7 @@ using CodeDesignPlus.Net.Core.Abstractions.Attributes;
 namespace CodeDesignPlus.Net.Serializers.Test.Helpers.DomainEvents;
 
 [EventKey("UserEntity", 1, "created")]
-public class UserCreatedDomainEvent(Guid aggregateId, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object>? metadata = null)
+public class UserCreatedDomainEvent(Guid aggregateId, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object>? metadata = null)
     : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public string? Name { get; set; }

--- a/packages/CodeDesignPlus.Net.Serializers/tests/CodeDesignPlus.Net.Serializers.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.Serializers/tests/CodeDesignPlus.Net.Serializers.Test/Usings.cs
@@ -1,3 +1,4 @@
 ﻿global using CodeDesignPlus.Net.Serializers.Exceptions;
 global using Xunit;
 global using Newtonsoft.Json;
+global using NodaTime;

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Utils/Reflection/TypeExtensions.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Utils/Reflection/TypeExtensions.cs
@@ -1,3 +1,5 @@
+using NodaTime;
+
 namespace CodeDesignPlus.Net.xUnit.Microservice.Utils.Reflection;
 
 /// <summary>
@@ -11,8 +13,9 @@ public static class TypeExtensions
         { typeof(int), () => 1 },
         { typeof(long), () => 1L },
         { typeof(Guid), () => Guid.NewGuid() },
-        { typeof(DateTime), () => DateTime.UtcNow },
+        { typeof(DateTime), () => DateTime.Now },
         { typeof(DateTimeOffset), () => DateTimeOffset.UtcNow },
+        { typeof(Instant), () => SystemClock.Instance.GetCurrentInstant() },
         { typeof(bool), () => true },
         { typeof(decimal), () => 1.0M },
         { typeof(float), () => 1.0F },

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.Microservice.Domain/DomainEvents/OrderCreatedDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.Microservice.Domain/DomainEvents/OrderCreatedDomainEvent.cs
@@ -1,6 +1,7 @@
 using CodeDesignPlus.Net.Core.Abstractions;
 using CodeDesignPlus.Net.Microservice.Domain.Entities;
 using CodeDesignPlus.Net.Microservice.Domain.ValueObjects;
+using NodaTime;
 
 namespace CodeDesignPlus.Net.Microservice.Domain.DomainEvents;
 
@@ -11,22 +12,22 @@ public class OrderCreatedDomainEvent(
    AddressValueObject address,
    Guid tenant,
    Guid createBy,
-   long createdAt,
+   Instant createdAt,
    Guid? eventId = null,
-   DateTime? occurredAt = null,
+   Instant? occurredAt = null,
    Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public string OrderStatus { get; } = orderStatus;
     public ClientEntity Client { get; } = client;
     public AddressValueObject Address { get; } = address;
-    public long CreatedAt { get; } = createdAt;
+    public Instant CreatedAt { get; } = createdAt;
     public Guid Tenant { get; private set; } = tenant;
     public Guid CreateBy { get; private set; } = createBy;
 
     public static OrderCreatedDomainEvent Create(Guid id, ClientEntity client, AddressValueObject address, Guid tenant, Guid creaateBy)
     {
-        return new OrderCreatedDomainEvent(id, "Created", client, address, tenant, creaateBy, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        return new OrderCreatedDomainEvent(id, "Created", client, address, tenant, creaateBy, SystemClock.Instance.GetCurrentInstant());
     }
 }
 

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.Microservice.Domain/Entities/ClientEntity.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.Microservice.Domain/Entities/ClientEntity.cs
@@ -1,17 +1,16 @@
-using System;
 using CodeDesignPlus.Net.Core.Abstractions;
+using NodaTime;
 
 namespace CodeDesignPlus.Net.Microservice.Domain.Entities;
-
 
 public class ClientEntity : IEntity
 {
     public Guid Id { get; set; }
     public required string Name { get; set; }
     public bool IsActive { get; set; }
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
     public Guid Tenant { get; set; }
 }

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.Microservice.Domain/OrderAggregate.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.Microservice.Domain/OrderAggregate.cs
@@ -1,5 +1,6 @@
 using CodeDesignPlus.Net.Core.Abstractions;
 using CodeDesignPlus.Net.Microservice.Domain.Entities;
+using NodaTime;
 
 namespace CodeDesignPlus.Net.Microservice.Domain;
 
@@ -15,7 +16,7 @@ public class OrderAggregate(Guid id) : AggregateRoot(id)
             Client = client, 
             OrderStatus = orderStatus,
             CreatedBy = createdBy,
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            CreatedAt = SystemClock.Instance.GetCurrentInstant()
         };
     }
 

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.xUnit.Microservice.Test/Helpers/AllTypesFake.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.xUnit.Microservice.Test/Helpers/AllTypesFake.cs
@@ -11,6 +11,7 @@ public class AllTypesFake
     public Guid GuidProperty { get; set; }
     public DateTime DateTimeProperty { get; set; }
     public DateTimeOffset DateTimeOffsetProperty { get; set; }
+    public Instant InstantProperty { get; set; }
     public bool BoolProperty { get; set; }
     public decimal DecimalProperty { get; set; }
     public float FloatProperty { get; set; }
@@ -31,6 +32,7 @@ public class AllTypesFake
     public Guid? NullableGuidProperty { get; set; }
     public DateTime? NullableDateTimeProperty { get; set; }
     public DateTimeOffset? NullableDateTimeOffsetProperty { get; set; }
+    public Instant? NullableInstantProperty { get; set; }
     public bool? NullableBoolProperty { get; set; }
     public decimal? NullableDecimalProperty { get; set; }
     public float? NullableFloatProperty { get; set; }

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.xUnit.Microservice.Test/Usings.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.xUnit.Microservice.Test/Usings.cs
@@ -10,3 +10,4 @@ global using System.Reflection;
 global using Xunit;
 global using CodeDesignPlus.Net.Microservice.Domain;
 global using CodeDesignPlus.Net.xUnit.Microservice.Test.Helpers;
+global using NodaTime;

--- a/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/Aggregate/OrderAggregate.cs
+++ b/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/Aggregate/OrderAggregate.cs
@@ -26,13 +26,13 @@ public class OrderAggregate : AggregateRoot
     {
         var aggregate = new OrderAggregate(id, name, description, price)
         {
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             CreatedBy = createBy,
             IsActive = true,
             Tenant = tenant
         };
 
-        aggregate.AddEvent(new OrderCreatedDomainEvent(id, name, description, price, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), createBy, null, metadata: new Dictionary<string, object>
+        aggregate.AddEvent(new OrderCreatedDomainEvent(id, name, description, price, SystemClock.Instance.GetCurrentInstant(), createBy, null, metadata: new Dictionary<string, object>
         {
             { "MetaKey1", "Value1" }
         }));
@@ -45,7 +45,7 @@ public class OrderAggregate : AggregateRoot
         Name = name;
         Description = description;
         Price = price;
-        UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        UpdatedAt = SystemClock.Instance.GetCurrentInstant();
         UpdatedBy = updatedBy;
 
         AddEvent(new OrderUpdatedDomainEvent(Id, name, description, price, UpdatedAt, updatedBy));
@@ -53,7 +53,7 @@ public class OrderAggregate : AggregateRoot
 
     public void Delete()
     {
-        UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        UpdatedAt = SystemClock.Instance.GetCurrentInstant();
 
         AddEvent(new OrderDeletedDomainEvent(Id, UpdatedAt));
     }

--- a/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/DomainEvents/OrderCreatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/DomainEvents/OrderCreatedDomainEvent.cs
@@ -10,18 +10,18 @@ public class OrderCreatedDomainEvent(
     string name,
     string description,
     decimal price,
-    long createdAt,
+    Instant createdAt,
     Guid createBy,
-    long? updatedAt,
+    Instant? updatedAt,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
     ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public string Name { get; private set; } = name;
     public string Description { get; private set; } = description;
     public decimal Price { get; private set; } = price;
-    public long CreatedAt { get; private set; } = createdAt;
+    public Instant CreatedAt { get; private set; } = createdAt;
     public Guid CreateBy { get; private set; } = createBy;
-    public long? UpdatedAt { get; private set; } = updatedAt;
+    public Instant? UpdatedAt { get; private set; } = updatedAt;
 }

--- a/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/DomainEvents/OrderDeletedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/DomainEvents/OrderDeletedDomainEvent.cs
@@ -9,7 +9,7 @@ public class OrderDeletedDomainEvent(
     Guid id,
     long? deletedAt,
     Guid? eventId = null,
-    DateTime? occurredAt = null
+    Instant? occurredAt = null
 ) : DomainEvent(id, eventId, occurredAt)
 {
     public long? DeletedAt { get; private set; } = deletedAt;

--- a/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/DomainEvents/OrderUpdatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/DomainEvents/OrderUpdatedDomainEvent.cs
@@ -10,10 +10,10 @@ public class OrderUpdatedDomainEvent(
     string name,
     string description,
     decimal price,
-    long? updatedAt,
+    Instant? updatedAt,
     Guid UpdatedBy,
     Guid? eventId = null,
-    DateTime? occurredAt = null
+    Instant? occurredAt = null
 ) : DomainEvent(id, eventId, occurredAt)
 {
     private readonly Guid updatedBy = UpdatedBy;
@@ -21,5 +21,5 @@ public class OrderUpdatedDomainEvent(
     public string Name { get; private set; } = name;
     public string Description { get; private set; } = description;
     public decimal Price { get; private set; } = price;
-    public long? UpdatedAt { get; private set; } = updatedAt;
+    public Instant? UpdatedAt { get; private set; } = updatedAt;
 }

--- a/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/Entity/ClientEntity.cs
+++ b/samples/CodeDesignPlus.Net.Core.Sample/src/CodeDesignPlus.Net.Core.Sample/Resources/Entity/ClientEntity.cs
@@ -5,9 +5,9 @@ namespace CodeDesignPlus.Net.Core.Sample.Resources.Entity;
 public class ClientEntity : IEntity
 {
     public bool IsActive { get; set; }
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
     public Guid Tenant { get; set; }
 

--- a/samples/CodeDesignPlus.Net.Criteria.Sample/src/CodeDesignPlus.Net.Criteria.Sample/Data.cs
+++ b/samples/CodeDesignPlus.Net.Criteria.Sample/src/CodeDesignPlus.Net.Criteria.Sample/Data.cs
@@ -22,7 +22,7 @@ public class OrdersData
                         Name = "Product 1.1",
                         Description = "Description Product 1",
                         Price = 50,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new Product
                     {
@@ -30,7 +30,7 @@ public class OrdersData
                         Name = "Product 1.2",
                         Description = "Description Product 2",
                         Price = 40,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ],
                 Client = new Client
@@ -46,7 +46,7 @@ public class OrdersData
                 Id = 2,
                 Name = "Order 2",
                 Description = "Description Order 2",
-                CreatedAt = DateTime.Now,
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Total = 200,
                 Products =
                 [
@@ -56,7 +56,7 @@ public class OrdersData
                         Name = "Product 2.1",
                         Description = "Description Product 1",
                         Price = 50,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new Product
                     {
@@ -64,7 +64,7 @@ public class OrdersData
                         Name = "Product 2.2",
                         Description = "Description Product 2",
                         Price = 150,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ],
                 Client = new Client
@@ -80,7 +80,7 @@ public class OrdersData
                 Id = 3,
                 Name = "Order 3",
                 Description = "Description Order 3",
-                CreatedAt = DateTime.Now,
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
                 Total = 300,
                 Products =
                 [
@@ -90,7 +90,7 @@ public class OrdersData
                         Name = "Product 3.1",
                         Description = "Description Product 1",
                         Price = 100,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     },
                     new Product
                     {
@@ -98,7 +98,7 @@ public class OrdersData
                         Name = "Product 3.2",
                         Description = "Description Product 2",
                         Price = 200,
-                        CreatedAt = DateTime.Now
+                        CreatedAt = SystemClock.Instance.GetCurrentInstant()
                     }
                 ],
                 Client = new Client

--- a/samples/CodeDesignPlus.Net.Criteria.Sample/src/CodeDesignPlus.Net.Criteria.Sample/Models/Order.cs
+++ b/samples/CodeDesignPlus.Net.Criteria.Sample/src/CodeDesignPlus.Net.Criteria.Sample/Models/Order.cs
@@ -10,7 +10,7 @@ public class Order
 
     public decimal Total { get; set; }
 
-    public DateTime CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
 
     public List<Product> Products { get; set; } = [];
 

--- a/samples/CodeDesignPlus.Net.Criteria.Sample/src/CodeDesignPlus.Net.Criteria.Sample/Models/Product.cs
+++ b/samples/CodeDesignPlus.Net.Criteria.Sample/src/CodeDesignPlus.Net.Criteria.Sample/Models/Product.cs
@@ -10,5 +10,5 @@ public class Product
 
     public decimal Price { get; set; }
 
-    public DateTime CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
 }

--- a/samples/CodeDesignPlus.Net.EFCore.Sample/src/CodeDesignPlus.Net.EFCore.Sample.OperationBase/Entities/OrderAggregate.cs
+++ b/samples/CodeDesignPlus.Net.EFCore.Sample/src/CodeDesignPlus.Net.EFCore.Sample.OperationBase/Entities/OrderAggregate.cs
@@ -25,7 +25,7 @@ public class OrderAggregate : AggregateRoot, IEntity
     {
         var aggregate = new OrderAggregate(id, name, description, price)
         {
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             CreatedBy = createBy,
             IsActive = true,
             Tenant = tenant
@@ -39,13 +39,13 @@ public class OrderAggregate : AggregateRoot, IEntity
         Name = name;
         Description = description;
         Price = price;
-        UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        UpdatedAt = SystemClock.Instance.GetCurrentInstant();
         UpdatedBy = updatedBy;
     }
 
     public void Delete(Guid updatedBy)
     {
-        UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        UpdatedAt = SystemClock.Instance.GetCurrentInstant();
         UpdatedBy = updatedBy;
     }
 }

--- a/samples/CodeDesignPlus.Net.EFCore.Sample/src/CodeDesignPlus.Net.EFCore.Sample.RepositoryBase/Entities/OrderAggregate.cs
+++ b/samples/CodeDesignPlus.Net.EFCore.Sample/src/CodeDesignPlus.Net.EFCore.Sample.RepositoryBase/Entities/OrderAggregate.cs
@@ -25,7 +25,7 @@ public class OrderAggregate : AggregateRoot, IEntity
     {
         var aggregate = new OrderAggregate(id, name, description, price)
         {
-            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
             CreatedBy = createBy,
             IsActive = true,
             Tenant = tenant
@@ -39,13 +39,13 @@ public class OrderAggregate : AggregateRoot, IEntity
         Name = name;
         Description = description;
         Price = price;
-        UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        UpdatedAt = SystemClock.Instance.GetCurrentInstant();
         UpdatedBy = updatedBy;
     }
 
     public void Delete(Guid updatedBy)
     {
-        UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        UpdatedAt = SystemClock.Instance.GetCurrentInstant();
         UpdatedBy = updatedBy;
     }
 }

--- a/samples/CodeDesignPlus.Net.Event.Sourcing.Sample/src/CodeDesignPlus.Net.Event.Sourcing.Sample/Events/NameUpdatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.Event.Sourcing.Sample/src/CodeDesignPlus.Net.Event.Sourcing.Sample/Events/NameUpdatedDomainEvent.cs
@@ -9,7 +9,7 @@ public class NameUpdatedDomainEvent(
     Guid aggregateId,
     string name,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.Event.Sourcing.Sample/src/CodeDesignPlus.Net.Event.Sourcing.Sample/Events/OrderCreatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.Event.Sourcing.Sample/src/CodeDesignPlus.Net.Event.Sourcing.Sample/Events/OrderCreatedDomainEvent.cs
@@ -11,7 +11,7 @@ public class OrderCreatedDomainEvent(
     string name,
     Guid idUser,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.Event.Sourcing.Sample/src/CodeDesignPlus.Net.Event.Sourcing.Sample/Events/ProductAddedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.Event.Sourcing.Sample/src/CodeDesignPlus.Net.Event.Sourcing.Sample/Events/ProductAddedDomainEvent.cs
@@ -9,7 +9,7 @@ public class ProductAddedDomainEvent(
     Guid aggregateId,
     string product,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Consumer.Sample/Events/NameUpdatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Consumer.Sample/Events/NameUpdatedDomainEvent.cs
@@ -9,7 +9,7 @@ public class NameUpdatedDomainEvent(
     Guid aggregateId,
     string name,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Consumer.Sample/Events/OrderCreatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Consumer.Sample/Events/OrderCreatedDomainEvent.cs
@@ -11,7 +11,7 @@ public class OrderCreatedDomainEvent(
     string name,
     Guid idUser,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Consumer.Sample/Events/ProductAddedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Consumer.Sample/Events/ProductAddedDomainEvent.cs
@@ -9,7 +9,7 @@ public class ProductAddedDomainEvent(
     Guid aggregateId,
     string product,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Producer.Sample/Events/NameUpdatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Producer.Sample/Events/NameUpdatedDomainEvent.cs
@@ -9,7 +9,7 @@ public class NameUpdatedDomainEvent(
     Guid aggregateId,
     string name,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Producer.Sample/Events/OrderCreatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Producer.Sample/Events/OrderCreatedDomainEvent.cs
@@ -11,7 +11,7 @@ public class OrderCreatedDomainEvent(
     string name,
     Guid idUser,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Producer.Sample/Events/ProductAddedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.EventStore.PubSub.Sample/src/CodeDesignPlus.Net.EventStore.PubSub.Producer.Sample/Events/ProductAddedDomainEvent.cs
@@ -9,7 +9,7 @@ public class ProductAddedDomainEvent(
     Guid aggregateId,
     string product,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.EventStore.Sample/src/CodeDesignPlus.Net.EventStore.Sample/Events/NameUpdatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.EventStore.Sample/src/CodeDesignPlus.Net.EventStore.Sample/Events/NameUpdatedDomainEvent.cs
@@ -9,7 +9,7 @@ public class NameUpdatedDomainEvent(
     Guid aggregateId,
     string name,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.EventStore.Sample/src/CodeDesignPlus.Net.EventStore.Sample/Events/OrderCreatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.EventStore.Sample/src/CodeDesignPlus.Net.EventStore.Sample/Events/OrderCreatedDomainEvent.cs
@@ -11,7 +11,7 @@ public class OrderCreatedDomainEvent(
     string name,
     Guid idUser,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.EventStore.Sample/src/CodeDesignPlus.Net.EventStore.Sample/Events/ProductAddedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.EventStore.Sample/src/CodeDesignPlus.Net.EventStore.Sample/Events/ProductAddedDomainEvent.cs
@@ -9,7 +9,7 @@ public class ProductAddedDomainEvent(
     Guid aggregateId,
     string product,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.Generator.Sample/src/CodeDesignPlus.Net.Generator.Application/Users/Commands/CreateUser/CreateUserCommand.cs
+++ b/samples/CodeDesignPlus.Net.Generator.Sample/src/CodeDesignPlus.Net.Generator.Application/Users/Commands/CreateUser/CreateUserCommand.cs
@@ -11,7 +11,7 @@ public class CreateUserCommand
 
     public required string Email { get; set; }
 
-    public DateTime Birthdate { get; set; }
+    public Instant Birthdate { get; set; }
 
     public required string Password { get; set; }
 

--- a/samples/CodeDesignPlus.Net.Kafka.Sample/src/CodeDesignPlus.Net.Kafka.Consumer.Sample/UserCreatedEvent.cs
+++ b/samples/CodeDesignPlus.Net.Kafka.Sample/src/CodeDesignPlus.Net.Kafka.Consumer.Sample/UserCreatedEvent.cs
@@ -12,7 +12,7 @@ public class UserCreatedEvent(
     string email,
     string? password = null,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.Kafka.Sample/src/CodeDesignPlus.Net.Kafka.Consumer.Sample/UserEntity.cs
+++ b/samples/CodeDesignPlus.Net.Kafka.Sample/src/CodeDesignPlus.Net.Kafka.Consumer.Sample/UserEntity.cs
@@ -8,9 +8,9 @@ public class UserEntity : IEntity
 {
     public Guid Id { get; set; }
     public bool IsActive { get; set; } 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 
     public required string Name { get; set; }

--- a/samples/CodeDesignPlus.Net.Kafka.Sample/src/CodeDesignPlus.Net.Kafka.Producer.Sample/UserCreatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.Kafka.Sample/src/CodeDesignPlus.Net.Kafka.Producer.Sample/UserCreatedDomainEvent.cs
@@ -11,7 +11,7 @@ public class UserCreatedDomainEvent(
     string email,
     string? password = null,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.Kafka.Sample/src/CodeDesignPlus.Net.Kafka.Producer.Sample/UserEntity.cs
+++ b/samples/CodeDesignPlus.Net.Kafka.Sample/src/CodeDesignPlus.Net.Kafka.Producer.Sample/UserEntity.cs
@@ -7,9 +7,9 @@ public class UserEntity : IEntity
 {
     public Guid Id { get; set; }
     public bool IsActive { get; set; } 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 
     public required string Name { get; set; }

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.OperationBase/Entities/ProductEntity.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.OperationBase/Entities/ProductEntity.cs
@@ -7,9 +7,9 @@ public class ProductEntity : IEntity
 {
     public Guid Id { get; set; }
     public bool IsActive { get; set; } 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 
     public required string Name { get; set; }

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.OperationBase/Entities/UserAggregate.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.OperationBase/Entities/UserAggregate.cs
@@ -16,7 +16,7 @@ public class UserAggregate(Guid id) : AggregateRoot(id)
         Tenant = tenant;
         IsActive = true;
         CreatedBy = createdBy;
-        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        CreatedAt = SystemClock.Instance.GetCurrentInstant();
     }
 
     public static UserAggregate Create(Guid id, string name, string email, Guid tenant, Guid createdBy)

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/DTOs/ProductDto.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/DTOs/ProductDto.cs
@@ -6,9 +6,9 @@ public class ProductDto: IDtoBase
 {
     public Guid Id { get; set; }
     public bool IsActive { get; set; } 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 
     public required string Name { get; set; }

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/DTOs/UserDto.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/DTOs/UserDto.cs
@@ -11,8 +11,8 @@ public class UserDto : IDto
     public List<ProductDto> Products { get; set; } = [];
     public Guid Tenant { get; set; }
     public bool IsActive { get; set; }
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 }

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Entities/ProductEntity.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Entities/ProductEntity.cs
@@ -7,9 +7,9 @@ public class ProductEntity : IEntity
 {
     public Guid Id { get; set; }
     public bool IsActive { get; set; } 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 
     public required string Name { get; set; }

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Entities/UserAggregate.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Entities/UserAggregate.cs
@@ -16,7 +16,7 @@ public class UserAggregate(Guid id) : AggregateRoot(id)
         Tenant = tenant;
         IsActive = true;
         CreatedBy = createdBy;
-        CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        CreatedAt = SystemClock.Instance.GetCurrentInstant();
     }
 
     public static UserAggregate Create(Guid id, string name, string email, Guid tenant, Guid createdBy)

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Program.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Program.cs
@@ -26,7 +26,7 @@ var product = new ProductEntity
 {
     Id = Guid.NewGuid(),
     Name = "Product 1",
-    CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+    CreatedAt = SystemClock.Instance.GetCurrentInstant(),
     CreatedBy = Guid.NewGuid(),
     IsActive = true
 };

--- a/samples/CodeDesignPlus.Net.PubSub.Sample/src/CodeDesignPlus.Net.PubSub.Sample/Entities/UserEntity.cs
+++ b/samples/CodeDesignPlus.Net.PubSub.Sample/src/CodeDesignPlus.Net.PubSub.Sample/Entities/UserEntity.cs
@@ -6,9 +6,9 @@ namespace CodeDesignPlus.Net.PubSub.Sample.Entities;
 public class UserEntity : IEntity
 {
     public bool IsActive { get; set; }
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
     public required string Name { get; set; }
 

--- a/samples/CodeDesignPlus.Net.PubSub.Sample/src/CodeDesignPlus.Net.PubSub.Sample/Handlers/UserCreatedEvent.cs
+++ b/samples/CodeDesignPlus.Net.PubSub.Sample/src/CodeDesignPlus.Net.PubSub.Sample/Handlers/UserCreatedEvent.cs
@@ -6,11 +6,11 @@ using CodeDesignPlus.Net.PubSub.Sample.Entities;
 namespace CodeDesignPlus.Net.PubSub.Sample.Handlers;
 
 [EventKey<UserEntity>(1, "created")]
-public class UserCreatedEvent(Guid aggregateId, string name, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object>? metadata = null) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
+public class UserCreatedEvent(Guid aggregateId, string name, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object>? metadata = null) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {
     public string Name { get; set; } = name;
 
-    public static UserCreatedEvent Create(Guid aggregateId, string name, Guid? eventId = null, DateTime? occurredAt = null, Dictionary<string, object>? metadata = null)
+    public static UserCreatedEvent Create(Guid aggregateId, string name, Guid? eventId = null, Instant? occurredAt = null, Dictionary<string, object>? metadata = null)
     {
         return new UserCreatedEvent(aggregateId, name, eventId, occurredAt, metadata);
     }

--- a/samples/CodeDesignPlus.Net.RabbitMQ.Sample/src/CodeDesignPlus.Net.RabbitMQ.Consumer.Sample/UserCreatedEvent.cs
+++ b/samples/CodeDesignPlus.Net.RabbitMQ.Sample/src/CodeDesignPlus.Net.RabbitMQ.Consumer.Sample/UserCreatedEvent.cs
@@ -10,7 +10,7 @@ public class UserCreatedEvent(
     string email,
     string? password = null,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.RabbitMQ.Sample/src/CodeDesignPlus.Net.RabbitMQ.Consumer.Sample/UserEntity.cs
+++ b/samples/CodeDesignPlus.Net.RabbitMQ.Sample/src/CodeDesignPlus.Net.RabbitMQ.Consumer.Sample/UserEntity.cs
@@ -7,9 +7,9 @@ public class UserEntity : IEntity
 {
     public Guid Id { get; set; }
     public bool IsActive { get; set; } 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 
     public required string Name { get; set; }

--- a/samples/CodeDesignPlus.Net.RabbitMQ.Sample/src/CodeDesignPlus.Net.RabbitMQ.Producer.Sample/UserCreatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.RabbitMQ.Sample/src/CodeDesignPlus.Net.RabbitMQ.Producer.Sample/UserCreatedDomainEvent.cs
@@ -10,7 +10,7 @@ public class UserCreatedDomainEvent(
     string email,
     string? password = null,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.RabbitMQ.Sample/src/CodeDesignPlus.Net.RabbitMQ.Producer.Sample/UserEntity.cs
+++ b/samples/CodeDesignPlus.Net.RabbitMQ.Sample/src/CodeDesignPlus.Net.RabbitMQ.Producer.Sample/UserEntity.cs
@@ -7,9 +7,9 @@ public class UserEntity : IEntity
 {
     public Guid Id { get; set; }
     public bool IsActive { get; set; } 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 
     public required string Name { get; set; }

--- a/samples/CodeDesignPlus.Net.Redis.PubSub.Sample/src/CodeDesignPlus.Net.Redis.PubSub.Consumer.Sample/UserCreatedEvent.cs
+++ b/samples/CodeDesignPlus.Net.Redis.PubSub.Sample/src/CodeDesignPlus.Net.Redis.PubSub.Consumer.Sample/UserCreatedEvent.cs
@@ -10,7 +10,7 @@ public class UserCreatedEvent(
     string email,
     string? password = null,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.Redis.PubSub.Sample/src/CodeDesignPlus.Net.Redis.PubSub.Consumer.Sample/UserEntity.cs
+++ b/samples/CodeDesignPlus.Net.Redis.PubSub.Sample/src/CodeDesignPlus.Net.Redis.PubSub.Consumer.Sample/UserEntity.cs
@@ -6,9 +6,9 @@ public class UserEntity : IEntity
 {
     public Guid Id { get; set; }
     public bool IsActive { get; set; } 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 
     public required string Name { get; set; }

--- a/samples/CodeDesignPlus.Net.Redis.PubSub.Sample/src/CodeDesignPlus.Net.Redis.PubSub.Producer.Sample/UserCreatedDomainEvent.cs
+++ b/samples/CodeDesignPlus.Net.Redis.PubSub.Sample/src/CodeDesignPlus.Net.Redis.PubSub.Producer.Sample/UserCreatedDomainEvent.cs
@@ -11,7 +11,7 @@ public class UserCreatedDomainEvent(
     string email,
     string? password = null,
     Guid? eventId = null,
-    DateTime? occurredAt = null,
+    Instant? occurredAt = null,
     Dictionary<string, object>? metadata = null
 ) : DomainEvent(aggregateId, eventId, occurredAt, metadata)
 {

--- a/samples/CodeDesignPlus.Net.Redis.PubSub.Sample/src/CodeDesignPlus.Net.Redis.PubSub.Producer.Sample/UserEntity.cs
+++ b/samples/CodeDesignPlus.Net.Redis.PubSub.Sample/src/CodeDesignPlus.Net.Redis.PubSub.Producer.Sample/UserEntity.cs
@@ -7,9 +7,9 @@ public class UserEntity : IEntity
 {
     public Guid Id { get; set; }
     public bool IsActive { get; set; } 
-    public long CreatedAt { get; set; }
+    public Instant CreatedAt { get; set; }
     public Guid CreatedBy { get; set; }
-    public long? UpdatedAt { get; set; }
+    public Instant? UpdatedAt { get; set; }
     public Guid? UpdatedBy { get; set; }
 
     public required string Name { get; set; }

--- a/samples/CodeDesignPlus.Net.Serializers.Sample/src/CodeDesignPlus.Net.Serializers.Sample/UserModel.cs
+++ b/samples/CodeDesignPlus.Net.Serializers.Sample/src/CodeDesignPlus.Net.Serializers.Sample/UserModel.cs
@@ -12,6 +12,6 @@ public class UserModel
 
     public string? Email { get; set; }
 
-    public DateTime Birthdate { get; set; }
+    public Instant Birthdate { get; set; }
 
 }


### PR DESCRIPTION
This pull request includes several changes to the `CodeDesignPlus.Net.Core` project, primarily focusing on replacing `DateTime` and `long` timestamp representations with `NodaTime.Instant` for better time handling. The changes span across multiple files, including core abstractions, domain events, and tests, as well as the addition of new package references.

### Timestamp Refactoring

* [`AggregateRootBase.cs`](diffhunk://#diff-a6f90710fbb288ad10d5650f84584842fcd19d181cd2fc0cecc03d67c488d655L23-R23): Changed `CreatedAt` and `UpdatedAt` properties from `long` to `Instant`. [[1]](diffhunk://#diff-a6f90710fbb288ad10d5650f84584842fcd19d181cd2fc0cecc03d67c488d655L23-R23) [[2]](diffhunk://#diff-a6f90710fbb288ad10d5650f84584842fcd19d181cd2fc0cecc03d67c488d655L33-R33)
* [`DomainEvent.cs`](diffhunk://#diff-cb6e8b90a4255bc37cd562c754e04db8987b0c9140340554d3e969d5005b4a2dL20-R20): Updated the `occurredAt` parameter and `OccurredAt` property from `DateTime` to `Instant`. [[1]](diffhunk://#diff-cb6e8b90a4255bc37cd562c754e04db8987b0c9140340554d3e969d5005b4a2dL20-R20) [[2]](diffhunk://#diff-cb6e8b90a4255bc37cd562c754e04db8987b0c9140340554d3e969d5005b4a2dL53-R53)
* [`IEntity.cs`](diffhunk://#diff-041148af552e64dccc675d6af6dfa4104ab60650509d6f366cb3d8ef4833cb4dL29-R37): Changed `CreatedAt` and `UpdatedAt` properties from `long` to `Instant`.

### Package and Usings Updates

* [`CodeDesignPlus.Net.Core.Abstractions.csproj`](diffhunk://#diff-ce1c6f7df9e9973bd719389121cef12d120e8ca9398bda6f20e125199a222bf8R39): Added `NodaTime` package reference.
* Various files: Added `NodaTime` to global usings. [[1]](diffhunk://#diff-62c51a8502d8fe77ce9a8e60a11a411ece5b5b31e1086dd904be8cb169716696L1-R5) [[2]](diffhunk://#diff-e1c2073a0e415e69f45ba5477caea162dfe0b4d36ba30ea073fc195b1a624507R2) [[3]](diffhunk://#diff-1a0207d18b93b1489b08968a7c516fbe238029bd0fddfc97b67d570bc505aa6aR13)

### Test Adjustments

* `AggregateRootTest.cs`, `DomainEventTest.cs`, `FakeEntity.cs`, `OrderAggregate.cs`, `OrderCreatedDomainEvent.cs`, `OrderDeletedDomainEvent.cs`, `OrderUpdatedDomainEvent.cs`, `PagerTest.cs`: Updated tests to use `SystemClock.Instance.GetCurrentInstant()` instead of `DateTimeOffset.UtcNow`. [[1]](diffhunk://#diff-d061627f94252d84619a6b3af68ac72aca9968f9146cfc384fd0ce2c53ea20ccL43-R44) [[2]](diffhunk://#diff-d061627f94252d84619a6b3af68ac72aca9968f9146cfc384fd0ce2c53ea20ccL54-R54) [[3]](diffhunk://#diff-0d6065e3be5d3a294f2e0509b19fd9a470c85859a80e0076c397697923bd4c0dL15-R17) [[4]](diffhunk://#diff-0d6065e3be5d3a294f2e0509b19fd9a470c85859a80e0076c397697923bd4c0dL36-R36) [[5]](diffhunk://#diff-0d6065e3be5d3a294f2e0509b19fd9a470c85859a80e0076c397697923bd4c0dL48-R52) [[6]](diffhunk://#diff-1b53d6a8bcd27ff012e9f53e9f97f6856ceaff5ad863983fe5f03f12f30481a6L8-R10) [[7]](diffhunk://#diff-1cb32b6ff8c0509cdedd5b0098f9b35fe5442fe50d026bd451120a9097b56629L29-R35) [[8]](diffhunk://#diff-1cb32b6ff8c0509cdedd5b0098f9b35fe5442fe50d026bd451120a9097b56629L48-R56) [[9]](diffhunk://#diff-6eb16f79c7c4719334e2e19b1cfd98845a723a3676a0861cd61a637561e1ae68L9-R22) [[10]](diffhunk://#diff-8ce2dded1f6f46fbbefdce8372771b97313f374412abae81ae6a4d2c887749aeL6-R11) [[11]](diffhunk://#diff-015fbc05509d4e5dfa24126f9ec429d3601cfc438315f481e554323ba6f4afcfL9-R20) [[12]](diffhunk://#diff-1124eda82b1b952f3bbf27609ecaf118ca1a577b9b33303c994ecf33081990a2L163-R163)

### Criteria Evaluator Enhancements

* [`Evaluator.cs`](diffhunk://#diff-8e617a8da32514f1f4abfaa469c8a4e23083b3d1f6caec40da652fcbd62f5752L1-R11): Added handling for `Instant` type in `CreateConstantExpression` method and included `NodaTime` and `NodaTime.Text` usings. [[1]](diffhunk://#diff-8e617a8da32514f1f4abfaa469c8a4e23083b3d1f6caec40da652fcbd62f5752L1-R11) [[2]](diffhunk://#diff-8e617a8da32514f1f4abfaa469c8a4e23083b3d1f6caec40da652fcbd62f5752R126-R132)
* [`CriteriaExtensionsTest.cs`](diffhunk://#diff-1e55033118fe43156699246e82d009a34aea0c7c668d4bda1516a681c853ecf4L218-R218): Updated test to use `Instant` instead of `DateTime`.