### PR TITLE
feat: simplify Instant serializer registration in MongoDB extensions

### DIFF
--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
@@ -46,12 +46,8 @@ public static class ServiceCollectionExtensions
             var mongoOptions = serviceProvider.GetRequiredService<IOptions<MongoOptions>>().Value;
 
             BsonSerializer.TryRegisterSerializer(GuidSerializer.StandardInstance);
-
-            if (BsonSerializer.LookupSerializer<Instant>() == null)
-                BsonSerializer.RegisterSerializer(new InstantSerializer());
-
-            if (BsonSerializer.LookupSerializer<Instant?>() == null)
-                BsonSerializer.RegisterSerializer(new NullableInstantSerializer());
+            BsonSerializer.TryRegisterSerializer(new InstantSerializer());
+            BsonSerializer.TryRegisterSerializer(new NullableInstantSerializer());
 
             var mongoUrl = MongoUrl.Create(mongoOptions.ConnectionString);
 


### PR DESCRIPTION
This pull request includes a change to the `AddMongo` method in the `ServiceCollectionExtensions` class to simplify the registration of BSON serializers.

Simplification of BSON serializer registration:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-d24305e8bb2351a50d429aba125542a6437e2ffa5d89bdb7f4cc32e5d533a20fL49-R50): Replaced individual checks and registrations for `Instant` and `Instant?` serializers with `TryRegisterSerializer` calls to streamline the code.