### PR TITLE
fix register serializer

### DIFF
--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs
@@ -46,8 +46,8 @@ public static class ServiceCollectionExtensions
             var mongoOptions = serviceProvider.GetRequiredService<IOptions<MongoOptions>>().Value;
 
             BsonSerializer.TryRegisterSerializer(GuidSerializer.StandardInstance);
-            BsonSerializer.TryRegisterSerializer(new InstantSerializer());
-            BsonSerializer.TryRegisterSerializer(new NullableInstantSerializer());
+            BsonSerializer.RegisterSerializer(new InstantSerializer());
+            BsonSerializer.RegisterSerializer(new NullableInstantSerializer());
 
             var mongoUrl = MongoUrl.Create(mongoOptions.ConnectionString);
 

--- a/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Operations/OperationBaseTest.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Operations/OperationBaseTest.cs
@@ -22,9 +22,7 @@ public class OperationBaseTest : IClassFixture<MongoContainer>
     {
         try
         {
-            BsonSerializer.TryRegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));            
-            BsonSerializer.TryRegisterSerializer(new InstantSerializer());
-            BsonSerializer.TryRegisterSerializer(new NullableInstantSerializer());
+            BsonSerializer.TryRegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
 
         }
         catch (Exception ex)


### PR DESCRIPTION
This pull request includes changes to the `CodeDesignPlus.Net.Mongo` package, specifically focusing on updating the registration of BSON serializers. The most important changes involve modifying how serializers are registered in both the service collection extension and the unit tests.

### Changes to BSON Serializer Registration:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-d24305e8bb2351a50d429aba125542a6437e2ffa5d89bdb7f4cc32e5d533a20fL49-R50): Updated the method to use `BsonSerializer.RegisterSerializer` instead of `BsonSerializer.TryRegisterSerializer` for `InstantSerializer` and `NullableInstantSerializer`.

* [`packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Operations/OperationBaseTest.cs`](diffhunk://#diff-f2698b045558ccdb9af708b5b67e0de7fcd5998f82305083d8669933fce365e6L26-L27): Removed the registration of `InstantSerializer` and `NullableInstantSerializer` in the `OperationBaseTest` constructor.