### PR TITLE
refactor: simplify serializer registration by removing unnecessary pa…

### DIFF
--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/MongoSerializerRegistration.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/MongoSerializerRegistration.cs
@@ -13,47 +13,45 @@ public static class MongoSerializerRegistration
     /// </summary>
     public static void RegisterSerializers()
     {
-        var serializer = BsonSerializer.SerializerRegistry as BsonSerializerRegistry;
-
-        RegisterGuidSerializer(serializer);
-        RegisterInstantSerializer(serializer);
-        RegisterNullableInstantSerializer(serializer);
+        RegisterGuidSerializer();
+        RegisterInstantSerializer();
+        RegisterNullableInstantSerializer();
     }
 
     /// <summary>
     /// Registers the <see cref="NullableInstantSerializer"/> if it has not been registered yet.
     /// </summary>
-    /// <param name="serializer">The <see cref="BsonSerializerRegistry"/> instance.</param>
-    private static void RegisterNullableInstantSerializer(BsonSerializerRegistry serializer)
+    private static void RegisterNullableInstantSerializer()
     {
-        var nullableInstantSerializer = serializer.GetSerializer<Instant?>();
-
-        if (nullableInstantSerializer is null)
+        try
+        {
             BsonSerializer.TryRegisterSerializer(new NullableInstantSerializer());
+        }
+        catch { }
     }
 
     /// <summary>
     /// Registers the <see cref="InstantSerializer"/> if it has not been registered yet.
     /// </summary>
-    /// <param name="serializer">The <see cref="BsonSerializerRegistry"/> instance.</param>
-    private static void RegisterInstantSerializer(BsonSerializerRegistry serializer)
+    private static void RegisterInstantSerializer()
     {
-        var instantSerializer = serializer.GetSerializer<Instant>();
-
-        if (instantSerializer is null)
+        try
+        {
             BsonSerializer.TryRegisterSerializer(new InstantSerializer());
+        }
+        catch { }
     }
 
     /// <summary>
     /// Registers the <see cref="GuidSerializer"/> if it has not been registered yet.
     /// </summary>
-    /// <param name="serializer">The <see cref="BsonSerializerRegistry"/> instance.</param>
-    private static void RegisterGuidSerializer(BsonSerializerRegistry serializer)
+    private static void RegisterGuidSerializer()
     {
-        var guidSerializer = serializer.GetSerializer<Guid>();
-
-        if (guidSerializer is not GuidSerializer)
+        try
+        {
             BsonSerializer.TryRegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
+        }
+        catch { }
     }
 }
 


### PR DESCRIPTION
This pull request includes changes to the `MongoSerializerRegistration` class to simplify the registration of serializers by removing the dependency on `BsonSerializerRegistry` and handling potential exceptions.

Simplification of serializer registration:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/MongoSerializerRegistration.cs`](diffhunk://#diff-4f0b267783d6f7c413fc3ff79b9f19b03e0ec9225c185a5c15102862776e10feL16-R55): Removed the `BsonSerializerRegistry` parameter from `RegisterGuidSerializer`, `RegisterInstantSerializer`, and `RegisterNullableInstantSerializer` methods, and added `try-catch` blocks to handle potential exceptions during the registration process.