### PR TITLE
fix: update Instant and NullableInstant serializers to use DateTime.U…

### DIFF
--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/MongoSerializerRegistration.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/MongoSerializerRegistration.cs
@@ -27,7 +27,10 @@ public static class MongoSerializerRegistration
         {
             BsonSerializer.TryRegisterSerializer(new NullableInstantSerializer());
         }
-        catch { }
+        catch
+        {
+            // the unit test will fail if the serializer is already registered
+        }
     }
 
     /// <summary>
@@ -39,7 +42,10 @@ public static class MongoSerializerRegistration
         {
             BsonSerializer.TryRegisterSerializer(new InstantSerializer());
         }
-        catch { }
+        catch
+        {
+            // the unit test will fail if the serializer is already registered
+        }
     }
 
     /// <summary>
@@ -51,7 +57,10 @@ public static class MongoSerializerRegistration
         {
             BsonSerializer.TryRegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
         }
-        catch { }
+        catch
+        {
+            // the unit test will fail if the serializer is already registered
+        }
     }
 }
 

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/InstantSerializer.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/InstantSerializer.cs
@@ -20,7 +20,7 @@ public class InstantSerializer : IBsonSerializer<Instant>
     {
         var dateTime = value.ToDateTimeUtc();
 
-        long millisecondsSinceEpoch = (dateTime - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).Ticks / TimeSpan.TicksPerMillisecond;
+        long millisecondsSinceEpoch = (dateTime - DateTime.UnixEpoch).Ticks / TimeSpan.TicksPerMillisecond;
 
         context.Writer.WriteDateTime(millisecondsSinceEpoch);
     }
@@ -38,7 +38,7 @@ public class InstantSerializer : IBsonSerializer<Instant>
         {
             long millisecondsSinceEpoch = context.Reader.ReadDateTime();
 
-            var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(millisecondsSinceEpoch);
+            var dateTime = DateTime.UnixEpoch.AddMilliseconds(millisecondsSinceEpoch);
 
             return Instant.FromDateTimeUtc(dateTime);
         }

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/NullableInstantSerializer.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/NullableInstantSerializer.cs
@@ -26,7 +26,7 @@ public class NullableInstantSerializer : IBsonSerializer<Instant?>
 
         var dateTime = value.Value.ToDateTimeUtc();
 
-        long millisecondsSinceEpoch = (dateTime - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).Ticks / TimeSpan.TicksPerMillisecond;
+        long millisecondsSinceEpoch = (dateTime - DateTime.UnixEpoch).Ticks / TimeSpan.TicksPerMillisecond;
 
         context.Writer.WriteDateTime(millisecondsSinceEpoch);
     }
@@ -50,7 +50,7 @@ public class NullableInstantSerializer : IBsonSerializer<Instant?>
         {
             long millisecondsSinceEpoch = context.Reader.ReadDateTime();
 
-            var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(millisecondsSinceEpoch);
+            var dateTime = DateTime.UnixEpoch.AddMilliseconds(millisecondsSinceEpoch);
 
             return Instant.FromDateTimeUtc(dateTime);
         }


### PR DESCRIPTION
This pull request includes changes to improve the error handling and code readability in the MongoDB serializers. The most important changes include adding comments to catch blocks in serializer registration methods and replacing hardcoded epoch values with `DateTime.UnixEpoch`.

Improvements to error handling:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/MongoSerializerRegistration.cs`](diffhunk://#diff-4f0b267783d6f7c413fc3ff79b9f19b03e0ec9225c185a5c15102862776e10feL30-R33): Added comments to the catch blocks in `RegisterNullableInstantSerializer`, `RegisterInstantSerializer`, and `RegisterGuidSerializer` methods to indicate that the unit test will fail if the serializer is already registered. [[1]](diffhunk://#diff-4f0b267783d6f7c413fc3ff79b9f19b03e0ec9225c185a5c15102862776e10feL30-R33) [[2]](diffhunk://#diff-4f0b267783d6f7c413fc3ff79b9f19b03e0ec9225c185a5c15102862776e10feL42-R48) [[3]](diffhunk://#diff-4f0b267783d6f7c413fc3ff79b9f19b03e0ec9225c185a5c15102862776e10feL54-R63)

Code readability improvements:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/InstantSerializer.cs`](diffhunk://#diff-b64c1141e5cf51bbe97470a8ab93f6aabdb26b4b5be2397e9d490deeab5a388bL23-R23): Replaced hardcoded epoch values with `DateTime.UnixEpoch` in the `Serialize` and `Deserialize` methods. [[1]](diffhunk://#diff-b64c1141e5cf51bbe97470a8ab93f6aabdb26b4b5be2397e9d490deeab5a388bL23-R23) [[2]](diffhunk://#diff-b64c1141e5cf51bbe97470a8ab93f6aabdb26b4b5be2397e9d490deeab5a388bL41-R41)
* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Serializers/NullableInstantSerializer.cs`](diffhunk://#diff-8a322e52e8953388d46248a3b16350e55150dfa858226055022cf10f9ed2132bL29-R29): Replaced hardcoded epoch values with `DateTime.UnixEpoch` in the `Serialize` and `Deserialize` methods. [[1]](diffhunk://#diff-8a322e52e8953388d46248a3b16350e55150dfa858226055022cf10f9ed2132bL29-R29) [[2]](diffhunk://#diff-8a322e52e8953388d46248a3b16350e55150dfa858226055022cf10f9ed2132bL53-R53)