### PR TITLE
fix: exclude abstract classes from domain event filtering in DeclareE…

### DIFF
--- a/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/DeclareExchangeBackgroundService.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/DeclareExchangeBackgroundService.cs
@@ -23,7 +23,7 @@ public class DeclareExchangeBackgroundService<TAssembly>(IChannelProvider channe
         {
             var types = typeof(TAssembly).Assembly.GetTypes();
 
-            var domainEvents = types.Where(x => x.IsSubclassOf(typeof(DomainEvent)));
+            var domainEvents = types.Where(x => !x.IsAbstract && x.IsSubclassOf(typeof(DomainEvent)));
 
             foreach (var domainEvent in domainEvents)
             {


### PR DESCRIPTION
This pull request includes a change to the `ExecuteAsync` method in the `DeclareExchangeBackgroundService` class to improve the filtering of domain events.

* [`packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/DeclareExchangeBackgroundService.cs`](diffhunk://#diff-4904e59a6a4ee18e07b8bcbec7a733bba2a86020311544760290145b71011087L26-R26): Modified the `domainEvents` query to exclude abstract classes by adding a check for `!x.IsAbstract`.