### PR TITLE
feat: add ITenant interface and implement tenant context in domain ev…

### DIFF
--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/IEventContext.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/IEventContext.cs
@@ -1,0 +1,57 @@
+namespace CodeDesignPlus.Net.Core.Abstractions;
+
+/// <summary>
+/// Represents a context for events, containing metadata and tenant information.
+/// </summary>
+public interface IEventContext
+{
+    /// <summary>
+    /// Gets the current domain event.
+    /// </summary>
+    IDomainEvent CurrentDomainEvent { get; }
+
+    /// <summary>
+    /// Gets or sets the tenant identifier.
+    /// </summary>
+    Guid Tenant { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventContext"/> class.
+    /// </summary>
+    /// <typeparam name="TEvent">The type of the domain event.</typeparam>
+    /// <param name="domainEvent">The current domain event.</param>
+    void SetCurrentDomainEvent<TEvent>(TEvent domainEvent) where TEvent : IDomainEvent;
+    
+    /// <summary>
+    /// Adds a metadata entry with the specified key and value.
+    /// </summary>
+    /// <param name="key">The key of the metadata entry.</param>
+    /// <param name="value">The value of the metadata entry.</param>
+    void AddMetadata(string key, object value);
+
+    /// <summary>
+    /// Gets the metadata value associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the metadata entry.</param>
+    /// <returns>The value of the metadata entry.</returns>
+    object GetMetadata(string key);
+
+    /// <summary>
+    /// Tries to get the metadata value associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the metadata entry.</param>
+    /// <param name="value">When this method returns, contains the value associated with the specified key, if the key is found; otherwise, the default value for the type of the value parameter. This parameter is passed uninitialized.</param>
+    /// <returns>true if the metadata contains an element with the specified key; otherwise, false.</returns>
+    bool TryGetMetadata(string key, out object value);
+
+    /// <summary>
+    /// Removes the metadata entry with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the metadata entry to remove.</param>
+    void RemoveMetadata(string key);
+
+    /// <summary>
+    /// Clears all metadata entries.
+    /// </summary>
+    void ClearMetadata();
+}

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/ITenant.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/ITenant.cs
@@ -1,0 +1,12 @@
+namespace CodeDesignPlus.Net.Core.Abstractions;
+
+/// <summary>
+/// Interface that defines the tenant identifier
+/// </summary>
+public interface ITenant
+{
+    /// <summary>
+    /// Get the tenant identifier
+    /// </summary>
+    Guid Tenant { get; }
+}

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core/Extensions/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ public static class ServiceCollectionExtensions
             .ValidateOnStart();
 
         services.TryAddSingleton<IDomainEventResolver, DomainEventResolverService>();
+        services.TryAddScoped<IEventContext, EventContext>();
         
         services.AddStartups(configuration);
 

--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core/Services/EventContext.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core/Services/EventContext.cs
@@ -1,0 +1,111 @@
+namespace CodeDesignPlus.Net.Core.Services;
+
+/// <summary>
+/// Represents a context for events, containing metadata and tenant information.
+/// </summary>
+public class EventContext: IEventContext, IDisposable
+{
+    private bool disposed;
+
+    private Dictionary<string, object> Metadata { get; set; } = []; 
+
+    /// <summary>
+    /// Gets the current domain event.
+    /// </summary>
+    public IDomainEvent CurrentDomainEvent { get; private set; }
+    
+    /// <summary>
+    /// Gets or sets the tenant identifier.
+    /// </summary>
+    public Guid Tenant { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventContext"/> class.
+    /// </summary>
+    /// <typeparam name="TEvent">The type of the domain event.</typeparam>
+    /// <param name="domainEvent">The current domain event.</param>
+    public void SetCurrentDomainEvent<TEvent>(TEvent domainEvent) where TEvent : IDomainEvent
+    {
+        if(this.CurrentDomainEvent != null)
+            throw new CoreException("The current domain event is already set.");
+
+        this.CurrentDomainEvent = domainEvent;
+
+        if(domainEvent is ITenant tenant)
+            this.Tenant = tenant.Tenant;
+    }
+
+    /// <summary>
+    /// Adds a metadata entry with the specified key and value.
+    /// </summary>
+    /// <param name="key">The key of the metadata entry.</param>
+    /// <param name="value">The value of the metadata entry.</param>
+    public void AddMetadata(string key, object value)
+    {
+        this.Metadata.Add(key, value);
+    }
+
+    /// <summary>
+    /// Gets the metadata value associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the metadata entry.</param>
+    /// <returns>The value of the metadata entry.</returns>
+    public object GetMetadata(string key)
+    {
+        return this.Metadata[key];
+    }
+
+    /// <summary>
+    /// Tries to get the metadata value associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the metadata entry.</param>
+    /// <param name="value">When this method returns, contains the value associated with the specified key, if the key is found; otherwise, the default value for the type of the value parameter. This parameter is passed uninitialized.</param>
+    /// <returns>true if the metadata contains an element with the specified key; otherwise, false.</returns>
+    public bool TryGetMetadata(string key, out object value)
+    {
+        return this.Metadata.TryGetValue(key, out value);
+    }
+
+    /// <summary>
+    /// Removes the metadata entry with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the metadata entry to remove.</param>
+    public void RemoveMetadata(string key)
+    {
+        this.Metadata.Remove(key);
+    }
+
+    /// <summary>
+    /// Clears all metadata entries.
+    /// </summary>
+    public void ClearMetadata()
+    {
+        this.Metadata.Clear();
+    }
+
+    /// <summary>
+    /// Releases all resources used by the current instance of the <see cref="EventContext"/> class.
+    /// </summary>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposed)
+        {
+            if (disposing)
+            {
+                this.Metadata.Clear();
+                this.Metadata = null;
+            }
+
+            disposed = true;
+        }
+    }
+
+    /// <summary>
+    /// Releases all resources used by the current instance of the <see cref="EventContext"/> class.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/ClientWithTenantDomainEvent.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Helpers/Domain/ClientWithTenantDomainEvent.cs
@@ -1,0 +1,21 @@
+using System;
+using NodaTime;
+
+namespace CodeDesignPlus.Net.Core.Test.Helpers.Domain;
+
+
+[EventKey<ProductAggregate>(1, "set-tenant-context", "ms-client")]
+public class ClientWithTenantDomainEvent
+(
+    Guid id,
+    string name,
+    Guid tenant,
+    Guid? eventId = null,
+    Instant? occurredAt = null
+) : DomainEvent(id, eventId, occurredAt), ITenant
+{
+
+    public string Name { get; private set; } = name;
+
+    public Guid Tenant { get; private set; } = tenant;
+}

--- a/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Services/EventContextTest.cs
+++ b/packages/CodeDesignPlus.Net.Core/tests/CodeDesignPlus.Net.Core.Test/Services/EventContextTest.cs
@@ -1,0 +1,145 @@
+using CodeDesignPlus.Net.Core.Services;
+using CodeDesignPlus.Net.Core.Test.Helpers.Domain;
+
+namespace CodeDesignPlus.Net.Core.Test.Services;
+
+public class EventContextTest
+{
+    [Fact]
+    public void SetCurrentDomainEvent_SetsCurrentDomainEvent()
+    {
+        // Arrange
+        var eventContext = new EventContext();
+        var tenant = Guid.NewGuid();
+        var domainEvent = new ClientWithTenantDomainEvent(Guid.NewGuid(), "Goku", tenant);
+
+        // Act
+        eventContext.SetCurrentDomainEvent(domainEvent);
+
+        // Assert
+        Assert.Equal(domainEvent, eventContext.CurrentDomainEvent);
+        Assert.Equal(tenant, eventContext.Tenant);
+    }
+
+    [Fact]
+    public void SetCurrentDomainEvent_ThrowsException_WhenCurrentDomainEventIsAlreadySet()
+    {
+        // Arrange
+        var eventContext = new EventContext();
+        var tenant = Guid.NewGuid();
+        var domainEvent = new ClientWithTenantDomainEvent(Guid.NewGuid(), "Goku", tenant);
+        eventContext.SetCurrentDomainEvent(domainEvent);
+
+        // Act & Assert
+        Assert.Throws<CoreException>(() => eventContext.SetCurrentDomainEvent(domainEvent));
+    }
+
+    [Fact]
+    public void AddMetadata_AddsMetadataEntry()
+    {
+        // Arrange
+        var eventContext = new EventContext();
+        var key = "key";
+        var value = "value";
+
+        // Act
+        eventContext.AddMetadata(key, value);
+
+        // Assert
+        Assert.Equal(value, eventContext.GetMetadata(key));
+    }
+
+    [Fact]
+    public void GetMetadata_ReturnsMetadataValue()
+    {
+        // Arrange
+        var eventContext = new EventContext();
+        var key = "key";
+        var value = "value";
+        eventContext.AddMetadata(key, value);
+
+        // Act
+        var result = eventContext.GetMetadata(key);
+
+        // Assert
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void TryGetMetadata_ReturnsTrue_WhenKeyExists()
+    {
+        // Arrange
+        var eventContext = new EventContext();
+        var key = "key";
+        var value = "value";
+        eventContext.AddMetadata(key, value);
+
+        // Act
+        var result = eventContext.TryGetMetadata(key, out var metadataValue);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(value, metadataValue);
+    }
+
+    [Fact]
+    public void TryGetMetadata_ReturnsFalse_WhenKeyDoesNotExist()
+    {
+        // Arrange
+        var eventContext = new EventContext();
+        var key = "key";
+
+        // Act
+        var result = eventContext.TryGetMetadata(key, out var metadataValue);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(metadataValue);
+    }
+
+    [Fact]
+    public void RemoveMetadata_RemovesMetadataEntry()
+    {
+        // Arrange
+        var eventContext = new EventContext();
+        var key = "key";
+        var value = "value";
+        eventContext.AddMetadata(key, value);
+
+        // Act
+        eventContext.RemoveMetadata(key);
+
+        // Assert
+        Assert.False(eventContext.TryGetMetadata(key, out _));
+    }
+
+    [Fact]
+    public void ClearMetadata_ClearsAllMetadataEntries()
+    {
+        // Arrange
+        var eventContext = new EventContext();
+        eventContext.AddMetadata("key1", "value1");
+        eventContext.AddMetadata("key2", "value2");
+
+        // Act
+        eventContext.ClearMetadata();
+
+        // Assert
+        Assert.False(eventContext.TryGetMetadata("key1", out _));
+        Assert.False(eventContext.TryGetMetadata("key2", out _));
+    }
+
+    [Fact]
+    public void Dispose_ClearsMetadataAndSetsDisposed()
+    {
+        // Arrange
+        var eventContext = new EventContext();
+        eventContext.AddMetadata("key", "value");
+
+        // Act
+        eventContext.Dispose();
+
+        // Assert
+        Assert.Throws<NullReferenceException>(() => eventContext.TryGetMetadata("key", out _));
+    }
+}

--- a/packages/CodeDesignPlus.Net.EventStore.PubSub/src/CodeDesignPlus.Net.EventStore.PubSub/Services/EventStorePubSubService.cs
+++ b/packages/CodeDesignPlus.Net.EventStore.PubSub/src/CodeDesignPlus.Net.EventStore.PubSub/Services/EventStorePubSubService.cs
@@ -141,7 +141,13 @@ public class EventStorePubSubService : IEventStorePubSub
         where TEvent : IDomainEvent
         where TEventHandler : IEventHandler<TEvent>
     {
+        using var scope = serviceProvider.CreateScope();
+
+        var context = scope.ServiceProvider.GetRequiredService<IEventContext>();
+
         var domainEvent = JsonSerializer.Deserialize<TEvent>(Encoding.UTF8.GetString(@event.Event.Data));
+
+        context.SetCurrentDomainEvent(domainEvent);
 
         var eventHandler = this.serviceProvider.GetRequiredService<TEventHandler>();
 

--- a/packages/CodeDesignPlus.Net.Kafka/src/CodeDesignPlus.Net.Kafka/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Kafka/src/CodeDesignPlus.Net.Kafka/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace CodeDesignPlus.Net.Kafka.Extensions;
+﻿using CodeDesignPlus.Net.Core.Extensions;
+
+namespace CodeDesignPlus.Net.Kafka.Extensions;
 
 /// <summary>
 /// Provides extension methods for adding Kafka services to the dependency injection container.

--- a/packages/CodeDesignPlus.Net.Kafka/src/CodeDesignPlus.Net.Kafka/Services/KafkaPubSub.cs
+++ b/packages/CodeDesignPlus.Net.Kafka/src/CodeDesignPlus.Net.Kafka/Services/KafkaPubSub.cs
@@ -153,7 +153,13 @@ public class KafkaPubSub(ILogger<KafkaPubSub> logger, IDomainEventResolver domai
             {
                 logger.LogInformation("{EventType} | Listener the event {Topic}", typeof(TEvent).Name, topic);
 
+                using var scope = serviceProvider.CreateScope();
+
+                var context = scope.ServiceProvider.GetRequiredService<IEventContext>();
+
                 var value = consumer.Consume(cancellationToken);
+
+                context.SetCurrentDomainEvent(value.Message.Value);
 
                 var eventHandler = serviceProvider.GetRequiredService<TEventHandler>();
 

--- a/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Services/KafkaPubSubTest.cs
+++ b/packages/CodeDesignPlus.Net.Kafka/tests/CodeDesignPlus.Net.Kafka.Test/Services/KafkaPubSubTest.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit.Abstractions;
 using CodeDesignPlus.Net.Kafka.Test.Helpers;
+using CodeDesignPlus.Net.Core.Services;
 
 namespace CodeDesignPlus.Net.Kafka.Test.Services;
 
@@ -113,7 +114,10 @@ public class KafkaPubSubTest
         _mockDomainEventResolverService.Setup(x => x.GetKeyDomainEvent<ProductCreatedEvent>()).Returns(topic);
 
         var mockConsumer = new Mock<IConsumer<string, ProductCreatedEvent>>();
-        var serviceCollection = new ServiceCollection().AddSingleton(x => mockConsumer.Object);
+        var serviceCollection = new ServiceCollection()
+            .AddSingleton(x => mockConsumer.Object)
+            .AddScoped<IEventContext, EventContext>();
+            
         var provider = serviceCollection.BuildServiceProvider();
         var maxAttempts = 3;
         var options = Microsoft.Extensions.Options.Options.Create(new KafkaOptions

--- a/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/FluentValidation/FluentExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/FluentValidation/FluentExtensions.cs
@@ -12,9 +12,10 @@ public static class FluentExtensions
     /// Adds FluentValidation validators from the current AppDomain's assemblies to the specified IServiceCollection.
     /// </summary>
     /// <param name="services">The IServiceCollection to add the validators to.</param>
+    /// <param name="lifetime">The lifetime of the validators.</param>
     /// <returns>The IServiceCollection with the added validators.</returns>
     /// <exception cref="ArgumentNullException">Thrown if no validator is found in the current AppDomain's assemblies.</exception>
-    public static IServiceCollection AddFluentValidation(this IServiceCollection services)
+    public static IServiceCollection AddFluentValidation(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped)
     {
         var validator = AppDomain.CurrentDomain
                    .GetAssemblies()
@@ -23,7 +24,7 @@ public static class FluentExtensions
 
         ArgumentNullException.ThrowIfNull(validator);
 
-        services.AddValidatorsFromAssembly(validator.Assembly);
+        services.AddValidatorsFromAssembly(validator.Assembly, lifetime);
 
         return services;
     }

--- a/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/MediatR/MediatRExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/MediatR/MediatRExtensions.cs
@@ -1,5 +1,4 @@
 using CodeDesignPlus.Net.Core.Abstractions;
-using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CodeDesignPlus.Net.Microservice.Commons.MediatR;
@@ -20,9 +19,11 @@ public static class MediatRExtensions
     {
         var assembly = typeof(TApplication).Assembly;
 
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(assembly));
+        services.AddMediatR(config => {
+            config.RegisterServicesFromAssemblies(assembly);
 
-        services.AddScoped(typeof(IPipelineBehavior<,>), typeof(ValidationPipeline<,>));
+            config.AddOpenBehavior(typeof(ValidationPipeline<,>));
+        });
 
         return services;
     }

--- a/packages/CodeDesignPlus.Net.Observability/tests/CodeDesignPlus.Net.Observability.Test/Extensions/ServiceCollectionExtensionsTest.cs
+++ b/packages/CodeDesignPlus.Net.Observability/tests/CodeDesignPlus.Net.Observability.Test/Extensions/ServiceCollectionExtensionsTest.cs
@@ -105,7 +105,7 @@ public class ServiceCollectionExtensionsTest
 
         // Assert
         Assert.NotEmpty(serviceCollection);
-        Assert.Equal(22, serviceCollection.Count);
+        Assert.Equal(23, serviceCollection.Count);
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class ServiceCollectionExtensionsTest
 
         // Assert
         Assert.NotEmpty(serviceCollection);
-        Assert.Equal(39, serviceCollection.Count);
+        Assert.Equal(40, serviceCollection.Count);
     }
 
     [Fact]
@@ -192,6 +192,6 @@ public class ServiceCollectionExtensionsTest
 
         // Assert
         Assert.NotEmpty(serviceCollection);
-        Assert.Equal(52, serviceCollection.Count);
+        Assert.Equal(53, serviceCollection.Count);
     }
 }

--- a/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/RabbitPubSubService.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Services/RabbitPubSubService.cs
@@ -156,12 +156,18 @@ public class RabbitPubSubService : IRabbitPubSub
         try
         {
             this.logger.LogDebug("Processing event: {TEvent}.", typeof(TEvent).Name);
+            
+            using var scope = this.serviceProvider.CreateScope();
+
+            var context = scope.ServiceProvider.GetRequiredService<IEventContext>();
 
             var body = eventArguments.Body.ToArray();
 
             var message = Encoding.UTF8.GetString(body);
 
             var @event = JsonSerializer.Deserialize<TEvent>(message);
+            
+            context.SetCurrentDomainEvent(@event);
 
             var eventHandler = this.serviceProvider.GetRequiredService<TEventHandler>();
 

--- a/packages/CodeDesignPlus.Net.Redis.PubSub/src/CodeDesignPlus.Net.Redis.PubSub/Services/RedisPubSubService.cs
+++ b/packages/CodeDesignPlus.Net.Redis.PubSub/src/CodeDesignPlus.Net.Redis.PubSub/Services/RedisPubSubService.cs
@@ -115,7 +115,13 @@ public class RedisPubSubService : IRedisPubSub
         where TEvent : IDomainEvent
         where TEventHandler : IEventHandler<TEvent>
     {
+        using var scope = serviceProvider.CreateScope();
+
+        var context = scope.ServiceProvider.GetRequiredService<IEventContext>();
+
         var @event = JsonSerializer.Deserialize<TEvent>(value);
+
+        context.SetCurrentDomainEvent(@event);
 
         var eventHandler = this.serviceProvider.GetRequiredService<TEventHandler>();
 

--- a/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace CodeDesignPlus.Net.Security.Extensions;
+﻿using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace CodeDesignPlus.Net.Security.Extensions;
 
 /// <summary>
 /// Provides extension methods for setting up security services in an <see cref="IServiceCollection"/> and configuring authentication in an <see cref="IApplicationBuilder"/>.
@@ -30,8 +32,9 @@ public static class ServiceCollectionExtensions
             .ValidateDataAnnotations();
 
         services
-            .AddSingleton<IUserContext, UserContext>()
-            .AddHttpContextAccessor()
+            .TryAddScoped<IUserContext, UserContext>();
+            
+        services.AddHttpContextAccessor()
             .AddAuthorization()
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(configuration, options);

--- a/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Services/UserContext.cs
+++ b/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Services/UserContext.cs
@@ -1,4 +1,6 @@
-﻿namespace CodeDesignPlus.Net.Security.Services;
+﻿using CodeDesignPlus.Net.Core.Abstractions;
+
+namespace CodeDesignPlus.Net.Security.Services;
 
 /// <summary>
 /// Provides user context information based on the current HTTP context.
@@ -8,7 +10,8 @@
 /// </remarks>
 /// <param name="httpContextAccessor">The HTTP context accessor.</param>
 /// <param name="options">The security options.</param>
-public class UserContext(IHttpContextAccessor httpContextAccessor, IOptions<SecurityOptions> options) : IUserContext
+/// <param name="eventContext">The event context.</param>
+public class UserContext(IHttpContextAccessor httpContextAccessor, IOptions<SecurityOptions> options, IEventContext eventContext) : IUserContext
 {
 
     /// <summary>
@@ -39,7 +42,7 @@ public class UserContext(IHttpContextAccessor httpContextAccessor, IOptions<Secu
     /// <summary>
     /// Gets the tenant ID from the request headers.
     /// </summary>
-    public Guid Tenant => this.GetHeader<Guid>("X-Tenant");
+    public Guid Tenant => this.GetTenant();
 
     /// <summary>
     /// Gets the current user's claims principal.
@@ -130,5 +133,19 @@ public class UserContext(IHttpContextAccessor httpContextAccessor, IOptions<Secu
         }
 
         return default;
+    }
+
+    /// <summary>
+    /// Gets the tenant identifier.
+    /// </summary>
+    /// <returns>The tenant identifier.</returns>
+    public Guid GetTenant()
+    {
+        var tenant = this.GetHeader<Guid>("X-Tenant");
+
+        if (tenant == Guid.Empty)
+            tenant = eventContext.Tenant;
+
+        return tenant;
     }
 }

--- a/packages/CodeDesignPlus.Net.Security/tests/CodeDesignPlus.Net.Security.Test/Extensions/ServiceCollectionExtensionsTest.cs
+++ b/packages/CodeDesignPlus.Net.Security/tests/CodeDesignPlus.Net.Security.Test/Extensions/ServiceCollectionExtensionsTest.cs
@@ -69,7 +69,7 @@ public class ServiceCollectionExtensionsTest
         var libraryService = serviceCollection.FirstOrDefault(x => x.ServiceType == typeof(IUserContext));
 
         Assert.NotNull(libraryService);
-        Assert.Equal(ServiceLifetime.Singleton, libraryService.Lifetime);
+        Assert.Equal(ServiceLifetime.Scoped, libraryService.Lifetime);
         Assert.Equal(typeof(UserContext), libraryService.ImplementationType);
     }
 

--- a/packages/CodeDesignPlus.Net.Security/tests/CodeDesignPlus.Net.Security.Test/Helpers/Server/ServerApi.cs
+++ b/packages/CodeDesignPlus.Net.Security/tests/CodeDesignPlus.Net.Security.Test/Helpers/Server/ServerApi.cs
@@ -1,4 +1,6 @@
-﻿using CodeDesignPlus.Net.Security.Extensions;
+﻿using CodeDesignPlus.Net.Core.Abstractions;
+using CodeDesignPlus.Net.Core.Services;
+using CodeDesignPlus.Net.Security.Extensions;
 using CodeDesignPlus.Net.xUnit.Extensions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
@@ -19,6 +21,7 @@ public class ServerApi
             .UseConfiguration(configuration)
             .ConfigureServices(x =>
             {
+                x.AddScoped<IEventContext, EventContext>();
                 x.AddSecurity(configuration, options);
                 x.AddRouting();
             })

--- a/packages/CodeDesignPlus.Net.Security/tests/CodeDesignPlus.Net.Security.Test/Helpers/Server/ServerAuth.cs
+++ b/packages/CodeDesignPlus.Net.Security/tests/CodeDesignPlus.Net.Security.Test/Helpers/Server/ServerAuth.cs
@@ -1,4 +1,6 @@
-﻿using IdentityModel.Client;
+﻿using CodeDesignPlus.Net.Core.Abstractions;
+using CodeDesignPlus.Net.Core.Services;
+using IdentityModel.Client;
 using IdentityServer4.Models;
 using IdentityServer4.Test;
 using Microsoft.AspNetCore.Builder;
@@ -23,6 +25,7 @@ public class ServerAuth
         var builder = new WebHostBuilder()
             .ConfigureServices((context, services) =>
             {
+                services.AddScoped<IEventContext, EventContext>();
                 services.AddControllers();
                 services.AddIdentityServer()
                     .AddInMemoryClients(


### PR DESCRIPTION
This pull request introduces a new `IEventContext` interface and its implementation, `EventContext`, to manage event metadata and tenant information. Additionally, it updates various services to utilize this context and includes tests to ensure the functionality works as expected.

Key changes include:

### New Interface and Implementation:
* `IEventContext` interface: Defines methods for managing event metadata and tenant information.
* `EventContext` class: Implements `IEventContext` and includes methods for handling metadata and tenant information, as well as disposing of resources.

### Service Updates:
* [`ServiceCollectionExtensions.cs`](diffhunk://#diff-8f8d755c73863113bf9347c2da7f53ec651c6541758929ef8c2b8819d637ce09R33): Registers `IEventContext` as a scoped service.
* `EventStorePubSubService.cs`, `KafkaPubSub.cs`, `RabbitPubSubService.cs`, and `RedisPubSubService.cs`: Updates to create a scope and set the current domain event in the `IEventContext`. [[1]](diffhunk://#diff-2ca6d234d0c7e4921d77b1531ad3b2777cf817fbc40cab3e511e44be3ce38466R144-R151) [[2]](diffhunk://#diff-90f4f3c02f2a326b375c0507da50380d5dd89ec23ab8bacf82842716322e891cR156-R163) [[3]](diffhunk://#diff-6adba99c032ad3318b91c870f7daea623e838b8aebf6a355baed903531db775dR160-R171) [[4]](diffhunk://#diff-9ce87ce58819a0f6099d112c054ec6a2a31424d61359d8e2d4f006645a787901R118-R125)

### Testing:
* [`EventContextTest.cs`](diffhunk://#diff-edae782c99fe6606421abc1b1c2c6b02f497f951a5b0e21e26f08840bdc83977R1-R145): Adds unit tests for `EventContext` to verify setting domain events, adding and retrieving metadata, and disposing of resources.

### Additional Changes:
* [`FluentExtensions.cs`](diffhunk://#diff-0f46199820751acabb13136c51fc43326c423bf934badd2d0cd2e60908848557R15-R18): Adds an optional parameter to specify the lifetime of FluentValidation validators. [[1]](diffhunk://#diff-0f46199820751acabb13136c51fc43326c423bf934badd2d0cd2e60908848557R15-R18) [[2]](diffhunk://#diff-0f46199820751acabb13136c51fc43326c423bf934badd2d0cd2e60908848557L26-R27)
* [`MediatRExtensions.cs`](diffhunk://#diff-b5ab2496b327bdc8ba08a022c0028161b01c0abb4c08400ce3e07024441c4ec0L23-R26): Updates MediatR configuration to add open behavior for validation pipeline.

These changes enhance the event handling capabilities by introducing a standardized context for managing event metadata and tenant information, improving code maintainability and testability.