### PR TITLE
fix: enhance error logging in DeclareExchangeBackgroundServiceTest to…

### DIFF
--- a/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Services/DeclareExchangeBackgroundServiceTest.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Services/DeclareExchangeBackgroundServiceTest.cs
@@ -42,7 +42,7 @@ public class DeclareExchangeBackgroundServiceTest
 
         // Assert
         // Verify that ExchangeDeclareAsync was called for each DomainEvent found in TestAssembly
-        loggerMock.VerifyLogging("An error occurred while declaring the exchanges.", LogLevel.Error, Times.Once());
+        loggerMock.VerifyLogging($"An error occurred while declaring the exchanges | Internal exception", LogLevel.Error, Times.Once());
 
         Assert.Equal("Internal exception", exception.Message);
     }


### PR DESCRIPTION
This pull request includes a small change to the `ExecuteAsync_InternalException_WriteLogger` method in the `DeclareExchangeBackgroundServiceTest.cs` file. The change updates the log message to include more detailed information about the internal exception. 

* [`packages/CodeDesignPlus.Net.RabbitMQ/tests/CodeDesignPlus.Net.RabbitMQ.Test/Services/DeclareExchangeBackgroundServiceTest.cs`](diffhunk://#diff-3e782ff8a7ec2903991d343300254ba10e12eb22194eed42d5db84e1c805e7dbL45-R45): Updated the log message to include "Internal exception" for better clarity.