### PR TITLE
feat: add asynchronous DeleteAsync method to IRepositoryBase and impl…

### DIFF
--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo.Abstractions/IRepositoryBase.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo.Abstractions/IRepositoryBase.cs
@@ -65,6 +65,16 @@ public interface IRepositoryBase
     /// <returns>A task that represents the asynchronous update operation.</returns>
     Task UpdateRangeAsync<TEntity>(List<TEntity> entities, CancellationToken cancellationToken) 
         where TEntity : class, IEntityBase;
+    
+    /// <summary>
+    /// Deletes an entity by its identifier asynchronously.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of the entity.</typeparam>
+    /// <param name="id">The identifier of the entity.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous delete operation.</returns>
+    Task DeleteAsync<TEntity>(Guid id, CancellationToken cancellationToken)
+        where TEntity : class, IEntityBase;
 
     /// <summary>
     /// Deletes an entity by its filter asynchronously.
@@ -76,7 +86,7 @@ public interface IRepositoryBase
     /// <returns>A task that represents the asynchronous delete operation.</returns>
     Task DeleteAsync<TEntity>(Guid id, Guid tenant, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase;
-
+    
     /// <summary>
     /// Deletes an entity asynchronously.
     /// </summary>

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Repository/RepositoryBase.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Repository/RepositoryBase.cs
@@ -132,7 +132,20 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
 
         return collection.Find(filter).AnyAsync(cancellationToken);
     }
-    
+
+    /// <summary>
+    /// Deletes an entity by its identifier asynchronously.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of the entity.</typeparam>
+    /// <param name="id">The identifier of the entity.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous delete operation.</returns>
+    public Task DeleteAsync<TEntity>(Guid id, CancellationToken cancellationToken)
+        where TEntity : class, IEntityBase
+    {
+        return this.DeleteAsync<TEntity>(id, Guid.Empty, cancellationToken);
+    }
+
     /// <summary>
     /// Deletes an entity by its filter asynchronously.
     /// </summary>

--- a/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Repository/RepositoryBaseTest.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Repository/RepositoryBaseTest.cs
@@ -205,6 +205,32 @@ public class RepositoryBaseTest
         // Assert
         Assert.True(result);
     }
+    
+    [Fact]
+    public async Task DeleteAsync_WhenIdIsValidWithoutTenant_ReturnTrue()
+    {
+        // Arrange
+        var cancellationToken = CancellationToken.None;
+
+        var repository = new ClientRepository(serviceProvider, this.options, loggerMock.Object);
+
+        var entity = new Client()
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test",
+            IsActive = true
+        };
+
+        await repository.CreateAsync(entity, cancellationToken);
+
+        // Act
+        await repository.DeleteAsync<Client>(entity.Id, cancellationToken);
+
+        var result = await collection.Find(x => x.Id == entity.Id).FirstOrDefaultAsync(cancellationToken);
+
+        // Assert
+        Assert.Null(result);
+    }
 
     [Fact]
     public async Task DeleteAsync_WhenIdIsValid_ReturnTrue()


### PR DESCRIPTION
This pull request introduces a new asynchronous delete method for entities in the repository and includes corresponding tests. The most important changes are as follows:

### New Method Addition:
* Added `DeleteAsync<TEntity>(Guid id, CancellationToken cancellationToken)` method to the `IRepositoryBase` interface to allow deletion of an entity by its identifier asynchronously.
* Implemented the `DeleteAsync<TEntity>(Guid id, CancellationToken cancellationToken)` method in the `RepositoryBase` class to support the new interface method.

### Testing:
* Added a new test `DeleteAsync_WhenIdIsValidWithoutTenant_ReturnTrue` in `RepositoryBaseTest.cs` to verify that the new delete method works correctly when an entity is deleted by its identifier without a tenant.