### PR TITLE
Fix traceIdentifier

### DIFF
--- a/packages/CodeDesignPlus.Net.Exceptions/src/CodeDesignPlus.Net.Exceptions/Models/ErrorResponse.cs
+++ b/packages/CodeDesignPlus.Net.Exceptions/src/CodeDesignPlus.Net.Exceptions/Models/ErrorResponse.cs
@@ -10,7 +10,7 @@ public record ErrorResponse(string TraceId, Layer Layer)
     /// <summary>
     /// Gets the list of error details associated with the error response.
     /// </summary>
-    public List<ErrorDetail> Errors { get; } = new();
+    public List<ErrorDetail> Errors { get; } = [];
 
     /// <summary>
     /// Adds an error detail to the error response.

--- a/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/EntryPoints/Rest/Middlewares/ExceptionMiddlware.cs
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/EntryPoints/Rest/Middlewares/ExceptionMiddlware.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using CodeDesignPlus.Net.Exceptions;
 using CodeDesignPlus.Net.Exceptions.Models;
@@ -47,8 +48,10 @@ public class ExceptionMiddleware(RequestDelegate next)
     {
         context.Response.ContentType = "application/json";
         context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+        
+        var traceId = Activity.Current.TraceId.ToString() ?? context.TraceIdentifier;
 
-        var response = new ErrorResponse(context.TraceIdentifier, exception.Layer);
+        var response = new ErrorResponse(traceId, exception.Layer);
 
         response.AddError(exception.Code, exception.Message, null);
 
@@ -68,7 +71,9 @@ public class ExceptionMiddleware(RequestDelegate next)
 
         var errors = exception.Errors.Select(e => new ErrorDetail(e.ErrorCode, e.PropertyName, e.ErrorMessage));
 
-        var response = new ErrorResponse(context.TraceIdentifier, Layer.Application);
+        var traceId = Activity.Current.TraceId.ToString() ?? context.TraceIdentifier;
+
+        var response = new ErrorResponse(traceId, Layer.Application);
 
         response.Errors.AddRange(errors);
 


### PR DESCRIPTION
This pull request includes several changes to improve error handling and tracing within the `CodeDesignPlus.Net` packages. The most important changes involve updates to the `ErrorResponse` model and the `ExceptionMiddleware` to enhance traceability and error detail management.

Improvements to error handling and tracing:

* [`packages/CodeDesignPlus.Net.Exceptions/src/CodeDesignPlus.Net.Exceptions/Models/ErrorResponse.cs`](diffhunk://#diff-8eb4d5eac33966f156dcfe8cdd5f2ee3a84aa79728462432799ca7e301f5d60cL13-R13): Changed the initialization of the `Errors` property to use an empty array instead of a new list instance.
* [`packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/EntryPoints/Rest/Middlewares/ExceptionMiddlware.cs`](diffhunk://#diff-d00eaa13b534a2f6563adb1b81b18335a13609a4db86d189764912619d1a3311R1): Added `System.Diagnostics` import for tracing purposes.
* [`packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/EntryPoints/Rest/Middlewares/ExceptionMiddlware.cs`](diffhunk://#diff-d00eaa13b534a2f6563adb1b81b18335a13609a4db86d189764912619d1a3311L51-R54): Updated the `HandleExceptionsAsync` method to use `Activity.Current.TraceId.ToString()` for trace ID, falling back to `context.TraceIdentifier` if necessary.
* [`packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/EntryPoints/Rest/Middlewares/ExceptionMiddlware.cs`](diffhunk://#diff-d00eaa13b534a2f6563adb1b81b18335a13609a4db86d189764912619d1a3311L71-R76): Updated the `HandleExceptionsAsync` method for `ValidationException` to use `Activity.Current.TraceId.ToString()` for trace ID, falling back to `context.TraceIdentifier` if necessary.