### PR TITLE
refactor: simplify CI workflow by removing unnecessary HEAD and base

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,11 +64,11 @@ jobs:
 
       - name: Run Affected Main
         if: env.IS_RELEASE == 'true'
-        run: npx nx show projects --affected --skip-nx-cache --head=HEAD --base=remotes/origin/main~1
+        run: npx nx show projects --affected --skip-nx-cache
 
       - name: Run Affected
         if: env.IS_RC == 'true' || env.IS_BETA == 'true'
-        run: npx nx show projects --affected --skip-nx-cache --head=HEAD --base=remotes/origin/main
+        run: npx nx show projects --affected --skip-nx-cache
 
       - name: SemVer 
         id: git-semver
@@ -103,36 +103,36 @@ jobs:
       # Main
       - name: Run SonarQube Main
         if: env.IS_RELEASE == 'true'
-        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube --head=HEAD --base=remotes/origin/main~1
+        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube
 
       - name: .Net Pack Main
         if: env.IS_RELEASE == 'true'
-        run: npx nx run-many --skip-nx-cache --target pack --head=HEAD --base=remotes/origin/main~1 --args="--version=${{ steps.git-semver.outputs.new-version }}"
+        run: npx nx run-many --skip-nx-cache --target pack --args="--version=${{ steps.git-semver.outputs.new-version }}"
 
       - name: .Net Push GitHub Package Main
         if: env.IS_RELEASE == 'true'
-        run: npx nx run-many --skip-nx-cache --target push --head=HEAD --base=remotes/origin/main~1 --args="--token=${{secrets.GITHUB_TOKEN}} --source=https://nuget.pkg.github.com/codedesignplus/index.json"
+        run: npx nx run-many --skip-nx-cache --target push --args="--token=${{secrets.GITHUB_TOKEN}} --source=https://nuget.pkg.github.com/codedesignplus/index.json"
         
       - name: .Net Push NuGet Package Main
         if: env.IS_RELEASE == 'true'
-        run: npx nx run-many --skip-nx-cache --target push --head=HEAD --base=remotes/origin/main~1 --args="--source=https://api.nuget.org/v3/index.json --token=${{env.NUGET_TOKEN}}"
+        run: npx nx run-many --skip-nx-cache --target push --args="--source=https://api.nuget.org/v3/index.json --token=${{env.NUGET_TOKEN}}"
       
       # Other Branches
       - name: Run SonarQube
         if: env.IS_RC == 'true' || env.IS_BETA == 'true'
-        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube --head=HEAD --base=remotes/origin/main
+        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube
         
       - name: .Net Pack
         if: env.IS_RC == 'true' || env.IS_BETA == 'true'
-        run: npx nx run-many --skip-nx-cache --target pack --head=HEAD --base=remotes/origin/main --args="--version=${{ steps.git-semver.outputs.new-version }}"
+        run: npx nx run-many --skip-nx-cache --target pack --args="--version=${{ steps.git-semver.outputs.new-version }}"
 
       - name: .Net Push GitHub Package
         if: env.IS_RC == 'true' || env.IS_BETA == 'true'
-        run: npx nx run-many --skip-nx-cache --target push --head=HEAD --base=remotes/origin/main --args="--token=${{secrets.GITHUB_TOKEN}} --source=https://nuget.pkg.github.com/codedesignplus/index.json"
+        run: npx nx run-many --skip-nx-cache --target push --args="--token=${{secrets.GITHUB_TOKEN}} --source=https://nuget.pkg.github.com/codedesignplus/index.json"
         
       - name: .Net Push NuGet Package
         if: env.IS_RC == 'true' || env.IS_BETA == 'true'
-        run: npx nx run-many --skip-nx-cache --target push --head=HEAD --base=remotes/origin/main --args="--source=https://api.nuget.org/v3/index.json --token=${{env.NUGET_TOKEN}}"
+        run: npx nx run-many --skip-nx-cache --target push --args="--source=https://api.nuget.org/v3/index.json --token=${{env.NUGET_TOKEN}}"
 
       - name: Push tag
         id: push_tag


### PR DESCRIPTION
This pull request includes changes to the CI workflow configuration in the `.github/workflows/ci.yaml` file. The main focus is to simplify the commands by removing unnecessary parameters.

Simplifications to CI workflow:

* Removed the `--head=HEAD --base=remotes/origin/main~1` parameters from the `npx nx show projects --affected` command for the "Run Affected Main" and "Run Affected" steps.
* Removed the `--head=HEAD --base=remotes/origin/main~1` parameters from the `npx nx run-many` command for the "Run SonarQube Main", ".Net Pack Main", ".Net Push GitHub Package Main", and ".Net Push NuGet Package Main" steps.
* Removed the `--head=HEAD --base=remotes/origin/main` parameters from the `npx nx run-many` command for the "Run SonarQube", ".Net Pack", ".Net Push GitHub Package", and ".Net Push NuGet Package" steps for RC and Beta branches.