### PR TITLE
refactor: replace Activator.CreateInstance with custom CreateInstance…

### DIFF
--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Utils/Reflection/TypeExtensions.cs
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Utils/Reflection/TypeExtensions.cs
@@ -142,7 +142,7 @@ public static class TypeExtensions
             }
             else if (property.PropertyType.IsClass && !property.PropertyType.IsAbstract)
             {
-                property.SetValue(instance, Activator.CreateInstance(property.PropertyType)!);
+                property.SetValue(instance,  CreateInstance(property.PropertyType)!);
             }
             else if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {


### PR DESCRIPTION
This pull request includes a modification to the `SetValueProperties` method in the `TypeExtensions` class to streamline the creation of class instances.

Codebase simplification:

* [`packages/CodeDesignPlus.Net.xUnit.Microservice/src/CodeDesignPlus.Net.xUnit.Microservice/Utils/Reflection/TypeExtensions.cs`](diffhunk://#diff-da888dfbb880cf4c592eab118757baa040c603eff54619602807d0088181ccb5L145-R145): Changed the method `Activator.CreateInstance` to `CreateInstance` for setting property values of class types.