### PR TITLE
test: update query URL in ServiceCollectionExtensionTest for correct …

### DIFF
--- a/packages/CodeDesignPlus.Net.Logger/tests/CodeDesignPlus.Net.Logger.Test/Extensions/ServiceCollectionExtensionTest.cs
+++ b/packages/CodeDesignPlus.Net.Logger/tests/CodeDesignPlus.Net.Logger.Test/Extensions/ServiceCollectionExtensionTest.cs
@@ -164,10 +164,11 @@ public class ServiceCollectionExtensionTest
 
         await Task.Delay(5000);
 
-        var url = "http://localhost:3100/loki/api/v1/query?query={job=\"ms-test\"}";
+        var url = "http://localhost:3100/loki/api/v1/query_range?query={job=\"ms-test\"}";
 
         var httpClient = new HttpClient();
         var response = await httpClient.GetAsync(url);
+
         response.EnsureSuccessStatusCode();
 
         var content = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
This pull request includes a small but important change to the `UseSerilog_SendsLogsToOpenTelemetryAndLoki_Success` test method. The change modifies the URL used in the HTTP GET request to query Loki logs.

* [`packages/CodeDesignPlus.Net.Logger/tests/CodeDesignPlus.Net.Logger.Test/Extensions/ServiceCollectionExtensionTest.cs`](diffhunk://#diff-e25d52eee5adc8882172dfda1874a31d379d0f913000991861f8665d613bce96L167-R171): Updated the URL from `query` to `query_range` in the Loki API endpoint to ensure proper querying of log data.