### PR TITLE
feat: add health check registration options for Redis and MongoDB con…

### DIFF
--- a/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/CodeDesignPlus.Net.Microservice.Commons.csproj
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/CodeDesignPlus.Net.Microservice.Commons.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\CodeDesignPlus.Net.Exceptions\src\CodeDesignPlus.Net.Exceptions\CodeDesignPlus.Net.Exceptions.csproj" />

--- a/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/CodeDesignPlus.Net.Microservice.Commons.csproj
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/CodeDesignPlus.Net.Microservice.Commons.csproj
@@ -34,10 +34,10 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Grpc.Net.Common" Version="2.67.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.2" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />

--- a/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/HealthChecks/HealthChecksExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/HealthChecks/HealthChecksExtensions.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace CodeDesignPlus.Net.Microservice.Commons.HealthChecks;
+
+/// <summary>
+/// Extension methods for setting up HealthChecks services in an <see cref="IServiceCollection"/>.
+/// </summary>
+public static class HealthChecksExtensions
+{
+    /// <summary>
+    /// Adds HealthChecks services to the specified <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddHealthChecks(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var builder = HealthCheckServiceCollectionExtensions.AddHealthChecks(services);
+
+        builder.AddCheck("self", () => HealthCheckResult.Healthy(), tags: ["live"]);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds HealthChecks services to the specified <see cref="IEndpointRouteBuilder"/>.
+    /// </summary>
+    /// <param name="app">The <see cref="IEndpointRouteBuilder"/> to add the services to.</param>
+    public static void UseHealthChecks(this IEndpointRouteBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        HealthCheckEndpointRouteBuilderExtensions.MapHealthChecks(app, "/health/ready", new HealthCheckOptions
+        {
+            Predicate = healthCheck => healthCheck.Tags.Contains("ready")
+        });
+
+        HealthCheckEndpointRouteBuilderExtensions.MapHealthChecks(app, "/health/live", new HealthCheckOptions
+        {
+            Predicate = healthCheck => healthCheck.Tags.Contains("live")
+        });
+    }
+}

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo.Abstractions/Options/MongoOptions.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo.Abstractions/Options/MongoOptions.cs
@@ -16,6 +16,10 @@ public class MongoOptions : IValidatableObject
     /// Gets or sets a value indicating whether MongoDB is enabled.
     /// </summary>
     public bool Enable { get; set; }
+    /// <summary>
+    /// Gets or sets a value indicating whether to register the health check.
+    /// </summary>
+    public bool RegisterHealthCheck { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the connection string for MongoDB.

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/CodeDesignPlus.Net.Mongo.csproj
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/CodeDesignPlus.Net.Mongo.csproj
@@ -37,7 +37,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />    
+    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeDesignPlus.Net.Mongo.Abstractions\CodeDesignPlus.Net.Mongo.Abstractions.csproj" />

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/CodeDesignPlus.Net.Mongo.csproj
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/CodeDesignPlus.Net.Mongo.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />    

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtension.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtension.cs
@@ -33,6 +33,9 @@ public static class ServiceCollectionExtensions
             .Bind(section)
             .ValidateDataAnnotations();
 
+        if(!options.Enable)
+            return services;
+
         if (options.Diagnostic.Enable)
             services.AddMongoDiagnostics(x =>
             {
@@ -68,6 +71,16 @@ public static class ServiceCollectionExtensions
 
         if (options.RegisterAutomaticRepositories)
             services.AddRepositories<TStartup>();
+
+        if (options.RegisterHealthCheck)
+            services
+                .AddHealthChecks()
+                .AddMongoDb(x =>
+                {
+                    var mongoClient = x.GetRequiredService<IMongoClient>();
+
+                    return mongoClient;
+                }, name: "MongoDB", tags: ["ready"]);
 
         return services;
     }

--- a/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ.Abstractions/Options/RabitMQOptions.cs
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ.Abstractions/Options/RabitMQOptions.cs
@@ -14,6 +14,11 @@ public class RabbitMQOptions : PubSubOptions, IValidatableObject
     /// Gets or sets a value indicating whether RabbitMQ is enabled.
     /// </summary>
     public bool Enable { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether to register the health check.
+    /// </summary>
+    public bool RegisterHealthCheck { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the RabbitMQ host.

--- a/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/CodeDesignPlus.Net.RabbitMQ.csproj
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/CodeDesignPlus.Net.RabbitMQ.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeDesignPlus.Net.RabbitMQ.Abstractions\CodeDesignPlus.Net.RabbitMQ.Abstractions.csproj" />

--- a/packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/CodeDesignPlus.Net.Redis.csproj
+++ b/packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/CodeDesignPlus.Net.Redis.csproj
@@ -41,5 +41,6 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/Options/RedisOptions.cs
+++ b/packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/Options/RedisOptions.cs
@@ -9,11 +9,14 @@ public class RedisOptions : IValidatableObject
     /// The configuration section name for Redis options.
     /// </summary>
     public const string Section = "Redis";
-
+    /// <summary>
+    /// Gets or sets the connection timeout in milliseconds.
+    /// </summary>
+    public bool RegisterHealthCheck { get; set; } = true;
     /// <summary>
     /// Gets or sets the dictionary of Redis instances.
     /// </summary>
-    public Dictionary<string, Instance> Instances { get; set; } = new();
+    public Dictionary<string, Instance> Instances { get; set; } = [];
 
     /// <summary>
     /// Validates the properties of the <see cref="RedisOptions"/> instance.


### PR DESCRIPTION
This pull request introduces health check functionality across multiple components in the project. The changes include adding health check packages, updating configuration options, and extending service collection methods to register health checks for MongoDB, RabbitMQ, and Redis.

### Health Check Integration:

* [`packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/CodeDesignPlus.Net.Microservice.Commons.csproj`](diffhunk://#diff-02128da5abf9635513e56e09447c110db1574fd2b31276c195eeac9d84a79a52R45): Added `Microsoft.Extensions.Diagnostics.HealthChecks` package.
* [`packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/HealthChecks/HealthChecksExtensions.cs`](diffhunk://#diff-d300ab3c35490f5a17efc6a359d6b98b1bf81929ceb80a356d0010b0700f2273R1-R48): Introduced `HealthChecksExtensions` class with methods to add and use health checks.

### MongoDB Health Checks:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo.Abstractions/Options/MongoOptions.cs`](diffhunk://#diff-41816590a3307b197e8cc771c2151d3eb3943d5b41e09f3851bbf79a6c34b642R19-R22): Added `RegisterHealthCheck` property to `MongoOptions` class.
* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/CodeDesignPlus.Net.Mongo.csproj`](diffhunk://#diff-ae5e85b2b93c088c63c4d8cfd8bb31640efd3934a2e59fa0118be6838f30cd80R41): Added `AspNetCore.HealthChecks.MongoDb` package.
* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Extensions/ServiceCollectionExtension.cs`](diffhunk://#diff-8c249e8e08833f5c84d566d431317b45c65ad590d5eeb427f6f5e84318a11dfdR36-R38): Updated `AddMongo` method to register MongoDB health checks if enabled. [[1]](diffhunk://#diff-8c249e8e08833f5c84d566d431317b45c65ad590d5eeb427f6f5e84318a11dfdR36-R38) [[2]](diffhunk://#diff-8c249e8e08833f5c84d566d431317b45c65ad590d5eeb427f6f5e84318a11dfdR75-R84)

### RabbitMQ Health Checks:

* [`packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ.Abstractions/Options/RabitMQOptions.cs`](diffhunk://#diff-3b86c8e867c338db0c214862d0f21a6e26b004b41efba873d9265db9a9c8ad3dR18-R22): Added `RegisterHealthCheck` property to `RabbitMQOptions` class.
* [`packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/CodeDesignPlus.Net.RabbitMQ.csproj`](diffhunk://#diff-3fe2a6794b879f879d0c7662b8b1426d3b55ec1c353421fd998582b283d90a73R40): Added `AspNetCore.HealthChecks.Rabbitmq` package.
* [`packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-ba617a9dedddf9c07be22e4c32f42b56cae2bd908d30c6875af3c7c8c23b94abL34-R36): Updated `AddRabbitMQ` method to register RabbitMQ health checks if enabled. [[1]](diffhunk://#diff-ba617a9dedddf9c07be22e4c32f42b56cae2bd908d30c6875af3c7c8c23b94abL34-R36) [[2]](diffhunk://#diff-ba617a9dedddf9c07be22e4c32f42b56cae2bd908d30c6875af3c7c8c23b94abL45-R47) [[3]](diffhunk://#diff-ba617a9dedddf9c07be22e4c32f42b56cae2bd908d30c6875af3c7c8c23b94abR59-R68)

### Redis Health Checks:

* [`packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/CodeDesignPlus.Net.Redis.csproj`](diffhunk://#diff-a5addfd6927ce4314eae4b3da0a3f9e0dccd0939ed1a068e0507dc40cf3bc533R44): Added `AspNetCore.HealthChecks.Redis` package.
* [`packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-d86e9ac40f63e069c1a76e52402b83ba954e09e3daacf905d1ade1d65f760dc0R26-R27): Updated `AddRedis` method to register Redis health checks if enabled. [[1]](diffhunk://#diff-d86e9ac40f63e069c1a76e52402b83ba954e09e3daacf905d1ade1d65f760dc0R26-R27) [[2]](diffhunk://#diff-d86e9ac40f63e069c1a76e52402b83ba954e09e3daacf905d1ade1d65f760dc0R44-R58)
* [`packages/CodeDesignPlus.Net.Redis/src/CodeDesignPlus.Net.Redis/Options/RedisOptions.cs`](diffhunk://#diff-b5dd0e628772f349c37d908b13ec36574e53f8a0494bcd071f1ac53b8df5154aL12-R19): Added `RegisterHealthCheck` property to `RedisOptions` class.