### PR TITLE
refactor: rename health check registration method and update RBAC pro…

### DIFF
--- a/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/HealthChecks/HealthChecksExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/HealthChecks/HealthChecksExtensions.cs
@@ -16,7 +16,7 @@ public static class HealthChecksExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-    public static IServiceCollection AddHealthChecks(this IServiceCollection services)
+    public static IServiceCollection AddHealthChecksServices(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 

--- a/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security.Abstractions/Options/SecurityOptions.cs
+++ b/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security.Abstractions/Options/SecurityOptions.cs
@@ -82,7 +82,7 @@ public class SecurityOptions
     /// <summary>
     /// Gets or sets a value indicating whether to validate the RBAC
     /// </summary>
-    public bool EnableRbac { get; set; }
+    public bool ValidateRbac { get; set; }
     /// <summary>
     /// Gets or sets the server to use in the RBAC
     /// </summary>

--- a/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Extensions/ServiceCollectionExtensions.cs
+++ b/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ public static class ServiceCollectionExtensions
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(configuration, options);
 
-        if (securityOptions.EnableRbac)
+        if (securityOptions.ValidateRbac)
         {
             services.AddGrpcClient<gRpc.Rbac.RbacClient>(o =>
             {
@@ -79,7 +79,7 @@ public static class ServiceCollectionExtensions
         if (options.EnableTenantContext && options.ValidateLicense)
             app.UseMiddleware<LicenseMiddleware>();
 
-        if (options.EnableRbac)
+        if (options.ValidateRbac)
             app.UseMiddleware<RbacMiddleware>();
 
         return app;


### PR DESCRIPTION
This pull request includes several changes to method names and property names to improve clarity and consistency in the `CodeDesignPlus.Net` project. The most important changes involve renaming methods and properties related to health checks and security options.

Changes to method names:

* [`packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/HealthChecks/HealthChecksExtensions.cs`](diffhunk://#diff-d300ab3c35490f5a17efc6a359d6b98b1bf81929ceb80a356d0010b0700f2273L19-R19): Renamed the `AddHealthChecks` method to `AddHealthChecksServices` to better reflect its purpose.

Changes to property names:

* [`packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security.Abstractions/Options/SecurityOptions.cs`](diffhunk://#diff-606f17da09e5e25b870a6a5afd8e00c80bf8cb5202b0264bf25720d5accce512L85-R85): Renamed the `EnableRbac` property to `ValidateRbac` for improved clarity.

Updates to method calls:

* [`packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-7d7fc2babc75eb3058ba65d0e022253c3db305f0d10c416187f22887866040efL48-R48): Updated the `AddSecurity` method to use the renamed `ValidateRbac` property.
* [`packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Extensions/ServiceCollectionExtensions.cs`](diffhunk://#diff-7d7fc2babc75eb3058ba65d0e022253c3db305f0d10c416187f22887866040efL82-R82): Updated the `UseAuth` method to use the renamed `ValidateRbac` property.