### PR TITLE
fix: update Swashbuckle.AspNetCore and RabbitMQ.Client package versio…

### DIFF
--- a/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/CodeDesignPlus.Net.Microservice.Commons.csproj
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/src/CodeDesignPlus.Net.Microservice.Commons/CodeDesignPlus.Net.Microservice.Commons.csproj
@@ -46,9 +46,9 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.2" />
     <PackageReference Include="MediatR" Version="12.4.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ.Abstractions/CodeDesignPlus.Net.RabbitMQ.Abstractions.csproj
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/src/CodeDesignPlus.Net.RabbitMQ.Abstractions/CodeDesignPlus.Net.RabbitMQ.Abstractions.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="RabbitMQ.Client" Version="7.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
     <ProjectReference Include="..\..\..\CodeDesignPlus.Net.PubSub\src\CodeDesignPlus.Net.PubSub\CodeDesignPlus.Net.PubSub.csproj" />
     <ProjectReference Include="..\..\..\CodeDesignPlus.Net.Exceptions\src\CodeDesignPlus.Net.Exceptions\CodeDesignPlus.Net.Exceptions.csproj" />
   </ItemGroup>

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.xUnit.Microservice.Api/CodeDesignPlus.Net.xUnit.Microservice.Api.csproj
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/tests/CodeDesignPlus.Net.xUnit.Microservice.Api/CodeDesignPlus.Net.xUnit.Microservice.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Program.cs">

--- a/packages/CodeDesignPlus.Net.xUnit/tests/CodeDesignPlus.Net.xUnit.Test/CodeDesignPlus.Net.xUnit.Test.csproj
+++ b/packages/CodeDesignPlus.Net.xUnit/tests/CodeDesignPlus.Net.xUnit.Test/CodeDesignPlus.Net.xUnit.Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageReference Include="RabbitMQ.Client" Version="7.1.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
     <PackageReference Include="VaultSharp" Version="1.17.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/samples/CodeDesignPlus.Net.Microservice.Commons.Sample/src/CodeDesignPlus.Net.Microservice.Rest.Sample/CodeDesignPlus.Net.Microservice.Rest.Sample.csproj
+++ b/samples/CodeDesignPlus.Net.Microservice.Commons.Sample/src/CodeDesignPlus.Net.Microservice.Rest.Sample/CodeDesignPlus.Net.Microservice.Rest.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\packages\CodeDesignPlus.Net.Microservice.Commons\src\CodeDesignPlus.Net.Microservice.Commons\CodeDesignPlus.Net.Microservice.Commons.csproj" />


### PR DESCRIPTION
This pull request includes several updates to package references across multiple project files. The primary focus is on upgrading the versions of `Swashbuckle.AspNetCore` and `RabbitMQ.Client` packages.

### Package Upgrades:
* Upgraded `Swashbuckle.AspNetCore.Swagger`, `Swashbuckle.AspNetCore.SwaggerGen`, and `Swashbuckle.AspNetCore.SwaggerUI` from version `7.2.0` to `7.3.1` in `CodeDesignPlus.Net.Microservice.Commons.csproj`.
* Upgraded `RabbitMQ.Client` from version `7.1.0` to `7.1.1` in `CodeDesignPlus.Net.RabbitMQ.Abstractions.csproj`.
* Upgraded `Swashbuckle.AspNetCore` from version `7.2.0` to `7.3.1` in `CodeDesignPlus.Net.xUnit.Microservice.Api.csproj`.
* Upgraded `RabbitMQ.Client` from version `7.1.0` to `7.1.1` in `CodeDesignPlus.Net.xUnit.Test.csproj`.
* Upgraded `Swashbuckle.AspNetCore` from version `7.2.0` to `7.3.0` in `CodeDesignPlus.Net.Microservice.Rest.Sample.csproj`.