### PR TITLE
feat: implement pagination support in repository methods and add Pagination

### DIFF
--- a/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/Models/Pager/Pagination.cs
+++ b/packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/Models/Pager/Pagination.cs
@@ -1,0 +1,43 @@
+namespace CodeDesignPlus.Net.Core.Abstractions.Models.Pager
+{
+    /// <summary>
+    /// Pagination class for paginated data.
+    /// </summary>
+    /// <typeparam name="T">The type of the data.</typeparam>
+    /// <param name="data">The data items.</param>
+    /// <param name="totalCount">The total count of items.</param>
+    /// <param name="limit">The maximum number of items to return.</param>
+    /// <param name="skip">The number of items to skip.</param>
+    public class Pagination<T>(IEnumerable<T> data, long totalCount, int limit, int skip)
+    {
+        /// <summary>
+        /// Gets the data items.
+        /// </summary>
+        public IEnumerable<T> Data { get; } = data;
+        /// <summary>
+        /// Gets the total count of items.
+        /// </summary>
+        public long TotalCount { get; } = totalCount;
+        /// <summary>
+        /// Gets the maximum number of items to return.
+        /// </summary>
+        public int Limit { get; } = limit;
+        /// <summary>
+        /// Gets the number of items to skip.
+        /// </summary>
+        public int Skip { get; } = skip;
+
+        /// <summary>
+        /// Creates a new instance of the Pagination class.
+        /// </summary>
+        /// <param name="items">The data items.</param>
+        /// <param name="totalCount">The total count of items.</param>
+        /// <param name="limit">The maximum number of items to return. If is null, defaults to 10.</param>
+        /// <param name="skip">The number of items to skip. If is null, defaults to 0.</param>
+        /// <returns>A new instance of the Pagination class.</returns>
+        public static Pagination<T> Create(IEnumerable<T> items, long totalCount, int? limit, int? skip)
+        {
+            return new Pagination<T>(items, totalCount, limit ?? 10, skip ?? 0);
+        }
+    }
+}

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo.Abstractions/IRepositoryBase.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo.Abstractions/IRepositoryBase.cs
@@ -1,4 +1,6 @@
-﻿namespace CodeDesignPlus.Net.Mongo.Abstractions;
+﻿using CodeDesignPlus.Net.Core.Abstractions.Models.Pager;
+
+namespace CodeDesignPlus.Net.Mongo.Abstractions;
 
 /// <summary>
 /// Defines the base repository operations for MongoDB.
@@ -189,7 +191,7 @@ public interface IRepositoryBase
     /// <param name="criteria">The criteria to match.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous find operation.</returns>
-    Task<List<TEntity>> MatchingAsync<TEntity>(C.Criteria criteria, CancellationToken cancellationToken) 
+    Task<Pagination<TEntity>> MatchingAsync<TEntity>(C.Criteria criteria, CancellationToken cancellationToken) 
         where TEntity : class, IEntityBase;
 
     /// <summary>
@@ -200,7 +202,7 @@ public interface IRepositoryBase
     /// <param name="tenant">The tenant identifier only for entities that inherit from <see cref="AggregateRoot"/>.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous matching operation.</returns>
-    Task<List<TEntity>> MatchingAsync<TEntity>(C.Criteria criteria, Guid tenant, CancellationToken cancellationToken) 
+    Task<Pagination<TEntity>> MatchingAsync<TEntity>(C.Criteria criteria, Guid tenant, CancellationToken cancellationToken) 
         where TEntity : class, IEntityBase;
 
     /// <summary>
@@ -212,7 +214,7 @@ public interface IRepositoryBase
     /// <param name="projection">The projection expression.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous find operation.</returns>
-    Task<List<TResult>> MatchingAsync<TEntity, TResult>(C.Criteria criteria, Expression<Func<TEntity, TResult>> projection, CancellationToken cancellationToken) 
+    Task<Pagination<TResult>> MatchingAsync<TEntity, TResult>(C.Criteria criteria, Expression<Func<TEntity, TResult>> projection, CancellationToken cancellationToken) 
         where TEntity : class, IEntityBase;
 
     /// <summary>
@@ -225,7 +227,7 @@ public interface IRepositoryBase
     /// <param name="tenant">The tenant identifier only for entities that inherit from <see cref="AggregateRoot"/>.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous matching operation.</returns>
-    Task<List<TResult>> MatchingAsync<TEntity, TResult>(C.Criteria criteria, Expression<Func<TEntity, TResult>> projection, Guid tenant, CancellationToken cancellationToken)
+    Task<Pagination<TResult>> MatchingAsync<TEntity, TResult>(C.Criteria criteria, Expression<Func<TEntity, TResult>> projection, Guid tenant, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase;
 
     /// <summary>
@@ -238,7 +240,7 @@ public interface IRepositoryBase
     /// <param name="projection">The projection expression.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous find operation.</returns>
-    Task<List<TProjection>> MatchingAsync<TEntity, TProjection>(Guid id, C.Criteria criteria, Expression<Func<TEntity, List<TProjection>>> projection, CancellationToken cancellationToken)
+    Task<Pagination<TProjection>> MatchingAsync<TEntity, TProjection>(Guid id, C.Criteria criteria, Expression<Func<TEntity, List<TProjection>>> projection, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase
         where TProjection : class, IEntityBase;
         
@@ -253,7 +255,7 @@ public interface IRepositoryBase
     /// <param name="tenant">The tenant identifier only for entities that inherit from <see cref="AggregateRoot"/>.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous matching operation.</returns>
-    Task<List<TProjection>> MatchingAsync<TEntity, TProjection>(Guid id, C.Criteria criteria, Expression<Func<TEntity, List<TProjection>>> projection, Guid tenant, CancellationToken cancellationToken)
+    Task<Pagination<TProjection>> MatchingAsync<TEntity, TProjection>(Guid id, C.Criteria criteria, Expression<Func<TEntity, List<TProjection>>> projection, Guid tenant, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase
         where TProjection : class, IEntityBase;
 }

--- a/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Repository/RepositoryBase.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Repository/RepositoryBase.cs
@@ -1,4 +1,4 @@
-﻿
+﻿using CodeDesignPlus.Net.Core.Abstractions.Models.Pager;
 using CodeDesignPlus.Net.Mongo.Extensions;
 
 namespace CodeDesignPlus.Net.Mongo.Repository;
@@ -327,7 +327,7 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
     /// <param name="criteria">The criteria to match.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous matching operation.</returns>
-    public Task<List<TEntity>> MatchingAsync<TEntity>(C.Criteria criteria, CancellationToken cancellationToken)
+    public Task<Pagination<TEntity>> MatchingAsync<TEntity>(C.Criteria criteria, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase
     {
         return this.MatchingAsync<TEntity>(criteria, Guid.Empty, cancellationToken);
@@ -341,12 +341,17 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
     /// <param name="tenant">The tenant identifier only for entities that inherit from <see cref="AggregateRoot"/>.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous matching operation.</returns>
-    public Task<List<TEntity>> MatchingAsync<TEntity>(C.Criteria criteria, Guid tenant, CancellationToken cancellationToken)
+    public async Task<Pagination<TEntity>> MatchingAsync<TEntity>(C.Criteria criteria, Guid tenant, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase
     {
-        var query = Query<TEntity>(criteria, tenant);
+        var filterExpression = criteria.GetFilterExpression<TEntity>();
+        var filter = filterExpression.ToFilterDefinition().BuildFilter(tenant);
+        var totalCount = await this.GetCollection<TEntity>().CountDocumentsAsync(filter, cancellationToken: cancellationToken);
 
-        return query.ToListAsync(cancellationToken);
+        var query = Query<TEntity>(criteria, tenant);
+        var data = await query.ToListAsync(cancellationToken);
+
+        return Pagination<TEntity>.Create(data, totalCount, criteria.Skip, criteria.Limit);
     }
 
     /// <summary>
@@ -358,7 +363,7 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
     /// <param name="projection">The projection expression.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous matching operation.</returns>
-    public Task<List<TResult>> MatchingAsync<TEntity, TResult>(C.Criteria criteria, Expression<Func<TEntity, TResult>> projection, CancellationToken cancellationToken)
+    public Task<Pagination<TResult>> MatchingAsync<TEntity, TResult>(C.Criteria criteria, Expression<Func<TEntity, TResult>> projection, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase
     {
         return this.MatchingAsync(criteria, projection, Guid.Empty, cancellationToken);
@@ -374,12 +379,17 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
     /// <param name="tenant">The tenant identifier only for entities that inherit from <see cref="AggregateRoot"/>.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous matching operation.</returns>
-    public Task<List<TResult>> MatchingAsync<TEntity, TResult>(C.Criteria criteria, Expression<Func<TEntity, TResult>> projection, Guid tenant, CancellationToken cancellationToken)
+    public async Task<Pagination<TResult>> MatchingAsync<TEntity, TResult>(C.Criteria criteria, Expression<Func<TEntity, TResult>> projection, Guid tenant, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase
     {
-        var query = Query<TEntity>(criteria, tenant);
+        var filterExpression = criteria.GetFilterExpression<TEntity>();
+        var filter = filterExpression.ToFilterDefinition().BuildFilter(tenant);
+        var totalCount = await this.GetCollection<TEntity>().CountDocumentsAsync(filter, cancellationToken: cancellationToken);
 
-        return query.Project(projection).ToListAsync(cancellationToken);
+        var query = Query<TEntity>(criteria, tenant);
+        var data = await query.Project(projection).ToListAsync(cancellationToken);
+
+        return Pagination<TResult>.Create(data, totalCount, criteria.Skip, criteria.Limit);
     }
 
 
@@ -393,7 +403,7 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
     /// <param name="projection">The projection expression.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous matching operation.</returns>
-    public Task<List<TProjection>> MatchingAsync<TEntity, TProjection>(Guid id, C.Criteria criteria, Expression<Func<TEntity, List<TProjection>>> projection, CancellationToken cancellationToken)
+    public Task<Pagination<TProjection>> MatchingAsync<TEntity, TProjection>(Guid id, C.Criteria criteria, Expression<Func<TEntity, List<TProjection>>> projection, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase
         where TProjection : class, IEntityBase
     {
@@ -411,7 +421,7 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
     /// <param name="tenant">The tenant identifier only for entities that inherit from <see cref="AggregateRoot"/>.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous matching operation.</returns>
-    public async Task<List<TProjection>> MatchingAsync<TEntity, TProjection>(Guid id, C.Criteria criteria, Expression<Func<TEntity, List<TProjection>>> projection, Guid tenant, CancellationToken cancellationToken)
+    public async Task<Pagination<TProjection>> MatchingAsync<TEntity, TProjection>(Guid id, C.Criteria criteria, Expression<Func<TEntity, List<TProjection>>> projection, Guid tenant, CancellationToken cancellationToken)
         where TEntity : class, IEntityBase
         where TProjection : class, IEntityBase
     {
@@ -425,7 +435,7 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
 
         var bsonFilter = ((BsonDocumentFilterDefinition<TProjection>)filterDefinition).Document;
 
-        var pipeline = new[]
+        var pipelineBase = new[]
         {
             new BsonDocument("$match", new BsonDocument("_id", new BsonBinaryData(id, GuidRepresentation.Standard))),
             new BsonDocument("$project", new BsonDocument
@@ -440,9 +450,25 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
             }),
             new BsonDocument("$unwind", new BsonDocument("path", $"${propertyName}")),
             new BsonDocument("$replaceRoot", new BsonDocument("newRoot", $"${propertyName}")),
-            new BsonDocument("$skip", criteria.Skip ?? 0), 
-            new BsonDocument("$limit", criteria.Limit ?? 10) 
         };
+
+        var pipeline = pipelineBase
+            .Concat(
+            [
+                new BsonDocument("$skip", criteria.Skip ?? 0),
+                new BsonDocument("$limit", criteria.Limit ?? 10)
+            ])
+            .ToList();
+        
+        var pipelineCount = pipelineBase
+            .Concat(
+            [
+                new BsonDocument("$count", "TotalCount")
+            ])
+            .ToList();
+
+        var countCursor = await collection.AggregateAsync<BsonDocument>(pipelineCount, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var totalCount = countCursor.FirstOrDefault(cancellationToken: cancellationToken)?["TotalCount"]?.AsInt32 ?? 0;
 
         var cursor = await collection.AggregateAsync<BsonDocument>(pipeline, cancellationToken: cancellationToken).ConfigureAwait(false);
         var resultList = new List<BsonDocument>();
@@ -452,7 +478,9 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
             resultList.AddRange(cursor.Current);
         }
 
-        return resultList.Select(doc => BsonSerializer.Deserialize<TProjection>(doc)).ToList();
+        var data = resultList.Select(doc => BsonSerializer.Deserialize<TProjection>(doc)).ToList();
+
+        return Pagination<TProjection>.Create(data, totalCount, criteria.Skip, criteria.Limit);
     }
 
     /// <summary>
@@ -488,7 +516,7 @@ public abstract class RepositoryBase(IServiceProvider serviceProvider, IOptions<
         {
             query = query.Limit(criteria.Limit.Value);
         }
-        
+
         return query;
     }
 

--- a/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Repository/RepositoryBaseTest.cs
+++ b/packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Repository/RepositoryBaseTest.cs
@@ -524,8 +524,8 @@ public class RepositoryBaseTest
 
         Assert.NotNull(order);
         Assert.NotNull(result);
-        Assert.NotEmpty(result);
-        Assert.Contains(result, x => x.Id == order.Id);
+        Assert.NotEmpty(result.Data);
+        Assert.Contains(result.Data, x => x.Id == order.Id);
     }
 
     [Fact]
@@ -558,8 +558,8 @@ public class RepositoryBaseTest
         var order = orders.First(x => x.Name == "Order 1");
         Assert.NotNull(order);
         Assert.NotNull(result);
-        Assert.NotEmpty(result);
-        Assert.Contains(result, x => x.Id == order.Id);
+        Assert.NotEmpty(result.Data);
+        Assert.Contains(result.Data, x => x.Id == order.Id);
     }
 
     [Fact]
@@ -592,7 +592,7 @@ public class RepositoryBaseTest
         }, cancellationToken);
 
         // Assert
-        var result = data.First();
+        var result = data.Data.First();
         var order = orders.First();
         Assert.NotNull(order);
         Assert.NotNull(result);
@@ -629,7 +629,7 @@ public class RepositoryBaseTest
         }, cancellationToken);
 
         // Assert
-        var result = data.First();
+        var result = data.Data.First();
         var order = orders.Last();
         Assert.NotNull(order);
         Assert.NotNull(result);
@@ -664,8 +664,8 @@ public class RepositoryBaseTest
         Assert.NotNull(order);
         Assert.NotNull(product);
         Assert.NotNull(result);
-        Assert.NotEmpty(result);
-        Assert.Contains(result, x => x.Id == product.Id);
+        Assert.NotEmpty(result.Data);
+        Assert.Contains(result.Data, x => x.Id == product.Id);
     }
 
     [Fact]

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/DTOs/ProductDto.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/DTOs/ProductDto.cs
@@ -1,4 +1,5 @@
 using CodeDesignPlus.Net.Core.Abstractions;
+using NodaTime;
 
 namespace CodeDesignPlus.Net.Mongo.Sample.RepositoryBase.DTOs;
 

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/DTOs/UserDto.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/DTOs/UserDto.cs
@@ -1,4 +1,5 @@
 using CodeDesignPlus.Net.Core.Abstractions;
+using NodaTime;
 
 namespace CodeDesignPlus.Net.Mongo.Sample.RepositoryBase.DTOs;
 

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Entities/ProductEntity.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Entities/ProductEntity.cs
@@ -1,5 +1,6 @@
 using System;
 using CodeDesignPlus.Net.Core.Abstractions;
+using NodaTime;
 
 namespace CodeDesignPlus.Net.Mongo.Sample.RepositoryBase.Entities;
 

--- a/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Entities/UserAggregate.cs
+++ b/samples/CodeDesignPlus.Net.Mongo.Sample/src/CodeDesignPlus.Net.Mongo.Sample.RepositoryBase/Entities/UserAggregate.cs
@@ -1,4 +1,5 @@
 using CodeDesignPlus.Net.Core.Abstractions;
+using NodaTime;
 
 namespace CodeDesignPlus.Net.Mongo.Sample.RepositoryBase.Entities;
 


### PR DESCRIPTION
This pull request introduces a `Pagination` class for handling paginated data and updates the repository methods to return `Pagination` objects instead of lists. Additionally, it modifies the related test cases to accommodate these changes.

### Introduction of Pagination:

* [`packages/CodeDesignPlus.Net.Core/src/CodeDesignPlus.Net.Core.Abstractions/Models/Pager/Pagination.cs`](diffhunk://#diff-275a212ad6609cc7f3cd29fa82b014e121e985d6ffb27fa2ef37454ec7971f08R1-R43): Added a new `Pagination` class for handling paginated data, including properties for `Data`, `TotalCount`, `Limit`, and `Skip`, and a static `Create` method for instantiating the class.

### Repository Method Updates:

* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo.Abstractions/IRepositoryBase.cs`](diffhunk://#diff-66e14ae57fe8dd0a47c3b3c8e9dde5c3ab62647d3a06d8a27dd517866985f4c8L192-R194): Updated the `MatchingAsync` methods to return `Pagination` objects instead of lists. [[1]](diffhunk://#diff-66e14ae57fe8dd0a47c3b3c8e9dde5c3ab62647d3a06d8a27dd517866985f4c8L192-R194) [[2]](diffhunk://#diff-66e14ae57fe8dd0a47c3b3c8e9dde5c3ab62647d3a06d8a27dd517866985f4c8L203-R205) [[3]](diffhunk://#diff-66e14ae57fe8dd0a47c3b3c8e9dde5c3ab62647d3a06d8a27dd517866985f4c8L215-R217) [[4]](diffhunk://#diff-66e14ae57fe8dd0a47c3b3c8e9dde5c3ab62647d3a06d8a27dd517866985f4c8L228-R230) [[5]](diffhunk://#diff-66e14ae57fe8dd0a47c3b3c8e9dde5c3ab62647d3a06d8a27dd517866985f4c8L241-R243) [[6]](diffhunk://#diff-66e14ae57fe8dd0a47c3b3c8e9dde5c3ab62647d3a06d8a27dd517866985f4c8L256-R258)
* [`packages/CodeDesignPlus.Net.Mongo/src/CodeDesignPlus.Net.Mongo/Repository/RepositoryBase.cs`](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaL330-R330): Implemented the `Pagination` logic in the `MatchingAsync` methods, including counting documents and creating `Pagination` instances. [[1]](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaL330-R330) [[2]](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaL344-R354) [[3]](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaL361-R366) [[4]](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaL377-R392) [[5]](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaL396-R406) [[6]](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaL414-R424) [[7]](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaL428-R438) [[8]](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaR453-R471) [[9]](diffhunk://#diff-f0c68be4c103f1480e7f70f84563d28fbd3d702710cb38bae4c004a9de8420aaL455-R483)

### Test Case Updates:

* [`packages/CodeDesignPlus.Net.Mongo/tests/CodeDesignPlus.Net.Mongo.Test/Repository/RepositoryBaseTest.cs`](diffhunk://#diff-0c123257cc9af5aaf46770267b834993d77203725797ad99f39df037572a671aL527-R528): Updated test cases to check the `Data` property of `Pagination` objects instead of the list directly. [[1]](diffhunk://#diff-0c123257cc9af5aaf46770267b834993d77203725797ad99f39df037572a671aL527-R528) [[2]](diffhunk://#diff-0c123257cc9af5aaf46770267b834993d77203725797ad99f39df037572a671aL561-R562) [[3]](diffhunk://#diff-0c123257cc9af5aaf46770267b834993d77203725797ad99f39df037572a671aL595-R595) [[4]](diffhunk://#diff-0c123257cc9af5aaf46770267b834993d77203725797ad99f39df037572a671aL632-R632) [[5]](diffhunk://#diff-0c123257cc9af5aaf46770267b834993d77203725797ad99f39df037572a671aL667-R668)