### PR TITLE
feat: update SonarQube commands to use server variable and remove har…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
       # Main
       - name: Run SonarQube Main
         if: env.IS_RELEASE == 'true'
-        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube
+        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube --args="--server=${{ vars.SERVER }}"
 
       - name: .Net Pack Main
         if: env.IS_RELEASE == 'true'
@@ -120,7 +120,7 @@ jobs:
       # Other Branches
       - name: Run SonarQube
         if: env.IS_RC == 'true'
-        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube
+        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube --args="--server=${{ vars.SERVER }}"
         
       - name: .Net Pack
         if: env.IS_RC == 'true' || env.IS_BETA == 'true'

--- a/packages/CodeDesignPlus.Net.Cache/project.json
+++ b/packages/CodeDesignPlus.Net.Cache/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Cache --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Cache",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -54,6 +54,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Core/project.json
+++ b/packages/CodeDesignPlus.Net.Core/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Core --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Core",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -54,6 +54,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Criteria/project.json
+++ b/packages/CodeDesignPlus.Net.Criteria/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Criteria --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Criteria",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.EFCore/project.json
+++ b/packages/CodeDesignPlus.Net.EFCore/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EFCore --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EFCore",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core**,**/CodeDesignPlus.Net.Redis**,**/CodeDesignPlus.Net.Security**,**/CodeDesignPlus.Net.Serializers**,**/CodeDesignPlus.Abstractions/**/*.cs,**/CodeDesignPlus.Entities/**/*.cs,**/CodeDesignPlus.InMemory/**/*.cs,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Event.Sourcing/project.json
+++ b/packages/CodeDesignPlus.Net.Event.Sourcing/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Event.Sourcing --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Event.Sourcing",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.xUnit/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.EventStore.PubSub/project.json
+++ b/packages/CodeDesignPlus.Net.EventStore.PubSub/project.json
@@ -50,7 +50,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore.PubSub --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore.PubSub",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.EventStore/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -58,6 +58,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.EventStore/project.json
+++ b/packages/CodeDesignPlus.Net.EventStore/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Exceptions/project.json
+++ b/packages/CodeDesignPlus.Net.Exceptions/project.json
@@ -47,7 +47,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Exceptions --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Exceptions",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.File.Storage/project.json
+++ b/packages/CodeDesignPlus.Net.File.Storage/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.File.Storage --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.File.Storage",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Generator/project.json
+++ b/packages/CodeDesignPlus.Net.Generator/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Generator --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Generator",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -54,6 +54,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Kafka/project.json
+++ b/packages/CodeDesignPlus.Net.Kafka/project.json
@@ -50,7 +50,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Kafka --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Kafka",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -58,6 +58,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Logger/project.json
+++ b/packages/CodeDesignPlus.Net.Logger/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Logger --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Logger",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Microservice.Commons/project.json
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/project.json
@@ -51,7 +51,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Microservice.Commons --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Microservice.Commons",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Exceptions/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -59,6 +59,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Mongo.Diagnostics/project.json
+++ b/packages/CodeDesignPlus.Net.Mongo.Diagnostics/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo.Diagnostics --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo.Diagnostics",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Mongo/project.json
+++ b/packages/CodeDesignPlus.Net.Mongo/project.json
@@ -51,7 +51,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Criteria/**,**/CodeDesignPlus.Net.Mongo.Diagnostics/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -59,6 +59,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Observability/project.json
+++ b/packages/CodeDesignPlus.Net.Observability/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Observability --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Observability",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.PubSub/project.json
+++ b/packages/CodeDesignPlus.Net.PubSub/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.PubSub --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.PubSub",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.RabbitMQ/project.json
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Redis.Cache/project.json
+++ b/packages/CodeDesignPlus.Net.Redis.Cache/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.Cache --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.Cache",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -54,6 +54,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Redis.PubSub/project.json
+++ b/packages/CodeDesignPlus.Net.Redis.PubSub/project.json
@@ -50,7 +50,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.PubSub --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.PubSub",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -58,6 +58,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Redis/project.json
+++ b/packages/CodeDesignPlus.Net.Redis/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Security/project.json
+++ b/packages/CodeDesignPlus.Net.Security/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Security --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Security",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Serializers/project.json
+++ b/packages/CodeDesignPlus.Net.Serializers/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Serializers --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Serializers",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.Vault/project.json
+++ b/packages/CodeDesignPlus.Net.Vault/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Vault --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Vault",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -54,6 +54,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.gRpc.Clients/project.json
+++ b/packages/CodeDesignPlus.Net.gRpc.Clients/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.gRpc.Clients --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.gRpc.Clients",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -54,6 +54,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/project.json
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.xUnit.Microservice --server=https://sonarcloud.io/",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.xUnit.Microservice",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Exceptions/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -57,6 +57,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {


### PR DESCRIPTION
This pull request updates the SonarQube integration across multiple configurations and projects, transitioning from hardcoded server URLs to more flexible parameterized configurations. Additionally, it introduces a default configuration for project-specific SonarQube execution.

### Workflow Updates:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL106-R106): Updated the `Run SonarQube` steps for both `Main` and `Other Branches` workflows to include a dynamic server URL using `${{ vars.SERVER }}`. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL106-R106) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL123-R123)

### Project Configuration Updates:
* Removed hardcoded SonarQube server URLs (e.g., `https://sonarcloud.io/`) from the `args` field in `project.json` files for all projects and replaced them with parameterized configurations. [[1]](diffhunk://#diff-95bec9969c74b182dad0b317f8c9118566166d5f9542c43dbfb6bd9fc89721e5L49-R61) [[2]](diffhunk://#diff-14e3c9faee8f5f2041415d96af9a732ebccbfde5ce29de549d5535c22262be45L49-R61) [[3]](diffhunk://#diff-ce161302dd328b6eba90785883e7dc54e39b54dfe8c83223032317228e89cd6eL52-R64) [[4]](diffhunk://#diff-a737bb61aac0431783f70978df30dab7adff4a8b2159db6bf6d5ed5ca0624977L52-R64) [[5]](diffhunk://#diff-bd73690730f9f40796c25b7590f5e15ab58bd9d78ca4b63f69e544bd70379172L52-R64) [[6]](diffhunk://#diff-8efc54bf37ecc84563178568d6cf6828ad12c4aed94016c85bad8fc85b1355c5L53-R65) [[7]](diffhunk://#diff-f49e0b1a4361cf2722df4fd6af511d936b083f6f66da0283c088385846c48ffaL52-R64) [[8]](diffhunk://#diff-903940d1f90078acdba043369c7f9a9a1b03c6cb210af98d6970790576bc9db4L50-R50) [[9]](diffhunk://#diff-462c109390dd0935bd3fe633250aee6e0e7f8c96b77aed68e4a37af64da9c184L52-R64) [[10]](diffhunk://#diff-7b3eb6476fd6f01355c35756e852ce8c4f00c18cd02f5149ca34a5cc6215aae7L49-R61) [[11]](diffhunk://#diff-0f5ba1573af7cc019f73013d6b085239caf554f84022ccc7b62b0fe6963eb007L53-R65) [[12]](diffhunk://#diff-80ad60d13734a7eb479d3d07d959743e5a96c272f14530541a9f4e125eee7930L52-R64) [[13]](diffhunk://#diff-f011ac4ee94f92e4420907f87c276155c87f7e7742c7694b2d4d64aedfc5e048L54-R66) [[14]](diffhunk://#diff-8a48cc7b618fdf02511eb4594965ebf6f37b3fb85a66efaafab1f529094f9d53L52-R64) [[15]](diffhunk://#diff-db0d881653d12af318ddc28300c31e20045b4eeb6789826abaa427b0fd986c99L54-R66) [[16]](diffhunk://#diff-41e91b6abeb1a2c5556bdf92d1ede16d44d2cb4b0e5bef5913445e0b36a15289L52-R64) [[17]](diffhunk://#diff-f87d812a1e9348a4842fa4bfb2c4b502066828ff3d2e45b7579643a8e18a3716L52-R64)
* Added a `configurations` section with a `default` configuration in each `project.json` file, specifying a new server URL (`http://sonarqube.codedesignplus.com:9000`) for SonarQube analysis. [[1]](diffhunk://#diff-95bec9969c74b182dad0b317f8c9118566166d5f9542c43dbfb6bd9fc89721e5L49-R61) [[2]](diffhunk://#diff-14e3c9faee8f5f2041415d96af9a732ebccbfde5ce29de549d5535c22262be45L49-R61) [[3]](diffhunk://#diff-ce161302dd328b6eba90785883e7dc54e39b54dfe8c83223032317228e89cd6eL52-R64) [[4]](diffhunk://#diff-a737bb61aac0431783f70978df30dab7adff4a8b2159db6bf6d5ed5ca0624977L52-R64) [[5]](diffhunk://#diff-bd73690730f9f40796c25b7590f5e15ab58bd9d78ca4b63f69e544bd70379172L52-R64) [[6]](diffhunk://#diff-8efc54bf37ecc84563178568d6cf6828ad12c4aed94016c85bad8fc85b1355c5L53-R65) [[7]](diffhunk://#diff-f49e0b1a4361cf2722df4fd6af511d936b083f6f66da0283c088385846c48ffaL52-R64) [[8]](diffhunk://#diff-903940d1f90078acdba043369c7f9a9a1b03c6cb210af98d6970790576bc9db4L50-R50) [[9]](diffhunk://#diff-462c109390dd0935bd3fe633250aee6e0e7f8c96b77aed68e4a37af64da9c184L52-R64) [[10]](diffhunk://#diff-7b3eb6476fd6f01355c35756e852ce8c4f00c18cd02f5149ca34a5cc6215aae7L49-R61) [[11]](diffhunk://#diff-0f5ba1573af7cc019f73013d6b085239caf554f84022ccc7b62b0fe6963eb007L53-R65) [[12]](diffhunk://#diff-80ad60d13734a7eb479d3d07d959743e5a96c272f14530541a9f4e125eee7930L52-R64) [[13]](diffhunk://#diff-f011ac4ee94f92e4420907f87c276155c87f7e7742c7694b2d4d64aedfc5e048L54-R66) [[14]](diffhunk://#diff-8a48cc7b618fdf02511eb4594965ebf6f37b3fb85a66efaafab1f529094f9d53L52-R64) [[15]](diffhunk://#diff-db0d881653d12af318ddc28300c31e20045b4eeb6789826abaa427b0fd986c99L54-R66) [[16]](diffhunk://#diff-41e91b6abeb1a2c5556bdf92d1ede16d44d2cb4b0e5bef5913445e0b36a15289L52-R64) [[17]](diffhunk://#diff-f87d812a1e9348a4842fa4bfb2c4b502066828ff3d2e45b7579643a8e18a3716L52-R64)