### PR TITLE
feat: update SonarQube project arguments to include server URL for al…

### DIFF
--- a/packages/CodeDesignPlus.Net.Cache/project.json
+++ b/packages/CodeDesignPlus.Net.Cache/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Cache",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Cache --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Core/project.json
+++ b/packages/CodeDesignPlus.Net.Core/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Core",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Core --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Criteria/project.json
+++ b/packages/CodeDesignPlus.Net.Criteria/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Criteria",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Criteria --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.EFCore/project.json
+++ b/packages/CodeDesignPlus.Net.EFCore/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EFCore",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EFCore --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core**,**/CodeDesignPlus.Net.Redis**,**/CodeDesignPlus.Net.Security**,**/CodeDesignPlus.Net.Serializers**,**/CodeDesignPlus.Abstractions/**/*.cs,**/CodeDesignPlus.Entities/**/*.cs,**/CodeDesignPlus.InMemory/**/*.cs,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Event.Sourcing/project.json
+++ b/packages/CodeDesignPlus.Net.Event.Sourcing/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Event.Sourcing",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Event.Sourcing --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.xUnit/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.EventStore.PubSub/project.json
+++ b/packages/CodeDesignPlus.Net.EventStore.PubSub/project.json
@@ -50,7 +50,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore.PubSub",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore.PubSub --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.EventStore/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.EventStore/project.json
+++ b/packages/CodeDesignPlus.Net.EventStore/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Exceptions/project.json
+++ b/packages/CodeDesignPlus.Net.Exceptions/project.json
@@ -47,7 +47,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Exceptions",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Exceptions --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
@@ -55,6 +55,11 @@
           "dotnet sonarscanner end"
         ],
         "parallel": false
+      },
+      "configurations": {
+        "default": {
+          "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Exceptions --server=http://sonarqube.codedesignplus.com:9000"
+        }
       }
     },
     "pack": {

--- a/packages/CodeDesignPlus.Net.File.Storage/project.json
+++ b/packages/CodeDesignPlus.Net.File.Storage/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.File.Storage",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.File.Storage --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Generator/project.json
+++ b/packages/CodeDesignPlus.Net.Generator/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Generator",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Generator --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Kafka/project.json
+++ b/packages/CodeDesignPlus.Net.Kafka/project.json
@@ -50,7 +50,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Kafka",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Kafka --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Logger/project.json
+++ b/packages/CodeDesignPlus.Net.Logger/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Logger",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Logger --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Microservice.Commons/project.json
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/project.json
@@ -51,7 +51,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Microservice.Commons",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Microservice.Commons --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Exceptions/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Mongo.Diagnostics/project.json
+++ b/packages/CodeDesignPlus.Net.Mongo.Diagnostics/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo.Diagnostics",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo.Diagnostics --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Mongo/project.json
+++ b/packages/CodeDesignPlus.Net.Mongo/project.json
@@ -51,7 +51,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Criteria/**,**/CodeDesignPlus.Net.Mongo.Diagnostics/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Observability/project.json
+++ b/packages/CodeDesignPlus.Net.Observability/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Observability",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Observability --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.PubSub/project.json
+++ b/packages/CodeDesignPlus.Net.PubSub/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.PubSub",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.PubSub --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.RabbitMQ/project.json
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Redis.Cache/project.json
+++ b/packages/CodeDesignPlus.Net.Redis.Cache/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.Cache",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.Cache --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Redis.PubSub/project.json
+++ b/packages/CodeDesignPlus.Net.Redis.PubSub/project.json
@@ -50,7 +50,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.PubSub",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.PubSub --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Redis/project.json
+++ b/packages/CodeDesignPlus.Net.Redis/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Security/project.json
+++ b/packages/CodeDesignPlus.Net.Security/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Security",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Security --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Serializers/project.json
+++ b/packages/CodeDesignPlus.Net.Serializers/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Serializers",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Serializers --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.Vault/project.json
+++ b/packages/CodeDesignPlus.Net.Vault/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Vault",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Vault --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.gRpc.Clients/project.json
+++ b/packages/CodeDesignPlus.Net.gRpc.Clients/project.json
@@ -46,7 +46,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.gRpc.Clients",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.gRpc.Clients --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/project.json
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/project.json
@@ -49,7 +49,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.xUnit.Microservice",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.xUnit.Microservice --server=http://sonarqube.codedesignplus.com:9000",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
           "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Exceptions/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",


### PR DESCRIPTION
This pull request updates the `args` configuration in multiple `project.json` files across various packages to include the `--server` parameter, specifying the SonarQube server URL. This change ensures that all projects use the same SonarQube server for code quality analysis and coverage reporting.

### Configuration Updates for SonarQube Integration:

* Added `--server=http://sonarqube.codedesignplus.com:9000` to the `args` configuration in the following `project.json` files:
  - `packages/CodeDesignPlus.Net.Cache/project.json`
  - `packages/CodeDesignPlus.Net.Core/project.json`
  - `packages/CodeDesignPlus.Net.Criteria/project.json`
  - `packages/CodeDesignPlus.Net.EFCore/project.json`
  - `packages/CodeDesignPlus.Net.Event.Sourcing/project.json`
  - `packages/CodeDesignPlus.Net.EventStore.PubSub/project.json`
  - `packages/CodeDesignPlus.Net.EventStore/project.json`
  - `packages/CodeDesignPlus.Net.Exceptions/project.json`
  - `packages/CodeDesignPlus.Net.File.Storage/project.json`
  - `packages/CodeDesignPlus.Net.Generator/project.json`
  - `packages/CodeDesignPlus.Net.Kafka/project.json`
  - `packages/CodeDesignPlus.Net.Logger/project.json`
  - `packages/CodeDesignPlus.Net.Microservice.Commons/project.json`
  - `packages/CodeDesignPlus.Net.Mongo.Diagnostics/project.json`
  - `packages/CodeDesignPlus.Net.Mongo/project.json`
  - `packages/CodeDesignPlus.Net.Observability/project.json`
  - `packages/CodeDesignPlus.Net.PubSub/project.json`
  - `packages/CodeDesignPlus.Net.RabbitMQ/project.json`
  - `packages/CodeDesignPlus.Net.Redis.Cache/project.json`
  - `packages/CodeDesignPlus.Net.Redis.PubSub/project.json`

### Additional Changes:

* In `packages/CodeDesignPlus.Net.Exceptions/project.json`, a new `configurations` section was added with a default configuration for the `args` parameter, including the SonarQube server URL.