### PR TITLE
feat: remove server argument from SonarQube run commands in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
       # Main
       - name: Run SonarQube Main
         if: env.IS_RELEASE == 'true'
-        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube --args="--server=${{ vars.SERVER }}"
+        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube
 
       - name: .Net Pack Main
         if: env.IS_RELEASE == 'true'
@@ -120,7 +120,7 @@ jobs:
       # Other Branches
       - name: Run SonarQube
         if: env.IS_RC == 'true'
-        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube --args="--server=${{ vars.SERVER }}"
+        run: npx nx run-many --skip-nx-cache --parallel 1 --target sonarqube
         
       - name: .Net Pack
         if: env.IS_RC == 'true' || env.IS_BETA == 'true'


### PR DESCRIPTION
This pull request makes adjustments to the SonarQube execution commands in the CI workflow configuration file `.github/workflows/ci.yaml`. The changes remove the use of the `--server` argument when running SonarQube tasks, simplifying the command.

Changes to CI workflow:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL106-R106): Updated the `Run SonarQube Main` and `Run SonarQube` steps to remove the `--server=${{ vars.SERVER }}` argument from the `npx nx run-many` command. This change applies to both the `Main` and `Other Branches` job configurations. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL106-R106) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL123-R123)