### PR TITLE
Refactor SonarScanner commands in project.json files to remove server…

### DIFF
--- a/packages/CodeDesignPlus.Net.Cache/project.json
+++ b/packages/CodeDesignPlus.Net.Cache/project.json
@@ -46,10 +46,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Cache --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Cache ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Core/project.json
+++ b/packages/CodeDesignPlus.Net.Core/project.json
@@ -46,10 +46,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Core --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Core ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Criteria/project.json
+++ b/packages/CodeDesignPlus.Net.Criteria/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Criteria --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Criteria ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.EFCore/project.json
+++ b/packages/CodeDesignPlus.Net.EFCore/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EFCore --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EFCore ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core**,**/CodeDesignPlus.Net.Redis**,**/CodeDesignPlus.Net.Security**,**/CodeDesignPlus.Net.Serializers**,**/CodeDesignPlus.Abstractions/**/*.cs,**/CodeDesignPlus.Entities/**/*.cs,**/CodeDesignPlus.InMemory/**/*.cs,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core**,**/CodeDesignPlus.Net.Redis**,**/CodeDesignPlus.Net.Security**,**/CodeDesignPlus.Net.Serializers**,**/CodeDesignPlus.Abstractions/**/*.cs,**/CodeDesignPlus.Entities/**/*.cs,**/CodeDesignPlus.InMemory/**/*.cs,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Event.Sourcing/project.json
+++ b/packages/CodeDesignPlus.Net.Event.Sourcing/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Event.Sourcing --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Event.Sourcing ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.xUnit/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.xUnit/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.EventStore.PubSub/project.json
+++ b/packages/CodeDesignPlus.Net.EventStore.PubSub/project.json
@@ -50,10 +50,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore.PubSub --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore.PubSub ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.EventStore/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.EventStore/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.EventStore/project.json
+++ b/packages/CodeDesignPlus.Net.EventStore/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.EventStore ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Event.Sourcing/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Exceptions/project.json
+++ b/packages/CodeDesignPlus.Net.Exceptions/project.json
@@ -47,10 +47,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Exceptions --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Exceptions ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.File.Storage/project.json
+++ b/packages/CodeDesignPlus.Net.File.Storage/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.File.Storage --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.File.Storage ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Generator/project.json
+++ b/packages/CodeDesignPlus.Net.Generator/project.json
@@ -46,10 +46,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Generator --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Generator ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Kafka/project.json
+++ b/packages/CodeDesignPlus.Net.Kafka/project.json
@@ -50,10 +50,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Kafka --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Kafka ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Logger/project.json
+++ b/packages/CodeDesignPlus.Net.Logger/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Logger --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Logger ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Microservice.Commons/project.json
+++ b/packages/CodeDesignPlus.Net.Microservice.Commons/project.json
@@ -51,10 +51,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Microservice.Commons --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Microservice.Commons ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Exceptions/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Exceptions/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Mongo.Diagnostics/project.json
+++ b/packages/CodeDesignPlus.Net.Mongo.Diagnostics/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo.Diagnostics --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo.Diagnostics ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Mongo/project.json
+++ b/packages/CodeDesignPlus.Net.Mongo/project.json
@@ -51,10 +51,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Mongo ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Criteria/**,**/CodeDesignPlus.Net.Mongo.Diagnostics/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Criteria/**,**/CodeDesignPlus.Net.Mongo.Diagnostics/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Observability/project.json
+++ b/packages/CodeDesignPlus.Net.Observability/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Observability --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Observability ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.PubSub/project.json
+++ b/packages/CodeDesignPlus.Net.PubSub/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.PubSub --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.PubSub ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.RabbitMQ/project.json
+++ b/packages/CodeDesignPlus.Net.RabbitMQ/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.RabbitMQ ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Redis.Cache/project.json
+++ b/packages/CodeDesignPlus.Net.Redis.Cache/project.json
@@ -46,10 +46,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.Cache --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.Cache ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Redis/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Redis.PubSub/project.json
+++ b/packages/CodeDesignPlus.Net.Redis.PubSub/project.json
@@ -50,10 +50,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.PubSub --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis.PubSub ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.PubSub/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Redis/project.json
+++ b/packages/CodeDesignPlus.Net.Redis/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Redis ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Security/project.json
+++ b/packages/CodeDesignPlus.Net.Security/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Security --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Security ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Serializers/project.json
+++ b/packages/CodeDesignPlus.Net.Serializers/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Serializers --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Serializers ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.Vault/project.json
+++ b/packages/CodeDesignPlus.Net.Vault/project.json
@@ -46,10 +46,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Vault --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.Vault ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Serializers/**,**/CodeDesignPlus.Net.Redis/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.gRpc.Clients/project.json
+++ b/packages/CodeDesignPlus.Net.gRpc.Clients/project.json
@@ -46,10 +46,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.gRpc.Clients --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.gRpc.Clients ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],

--- a/packages/CodeDesignPlus.Net.xUnit.Microservice/project.json
+++ b/packages/CodeDesignPlus.Net.xUnit.Microservice/project.json
@@ -49,10 +49,10 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.xUnit.Microservice --server=http://sonarqube.codedesignplus.com:9000",
+        "args": "--org=codedesignplus --project=CodeDesignPlus.Net.xUnit.Microservice ",
         "commands": [
           "dotnet test {projectRoot}/{args.project}.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover",
-          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url={args.server} /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Exceptions/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
+          "dotnet sonarscanner begin /o:{args.org} /k:{args.project} /d:sonar.host.url=http://sonarqube.codedesignplus.com:9000 /d:sonar.coverage.exclusions=\"**/CodeDesignPlus.Net.Core/**,**/CodeDesignPlus.Net.Exceptions/**,**/CodeDesignPlus.Net.Security/**,**/CodeDesignPlus.Net.Serializers/**,**Tests*.cs\" /d:sonar.cs.opencover.reportsPaths={projectRoot}/tests/{args.project}.Test/coverage.opencover.xml",
           "dotnet build {projectRoot}/{args.project}.sln",
           "dotnet sonarscanner end"
         ],


### PR DESCRIPTION
This pull request updates multiple `project.json` files across various packages to simplify the configuration of SonarQube analysis commands. The changes remove the dynamic server argument (`--server`) and replace it with a hardcoded SonarQube server URL. Additionally, the `args` option no longer includes the `--server` parameter, as it is now directly embedded in the SonarQube command.

### Changes to SonarQube Configuration:

* Removed the `--server` argument from the `args` option in all `project.json` files. The SonarQube server URL is now hardcoded within the SonarQube commands. (`packages/CodeDesignPlus.Net.Cache/project.json` - [[1]](diffhunk://#diff-95bec9969c74b182dad0b317f8c9118566166d5f9542c43dbfb6bd9fc89721e5L49-R52) `packages/CodeDesignPlus.Net.Core/project.json` - [[2]](diffhunk://#diff-14e3c9faee8f5f2041415d96af9a732ebccbfde5ce29de549d5535c22262be45L49-R52) `packages/CodeDesignPlus.Net.Criteria/project.json` - [[3]](diffhunk://#diff-ce161302dd328b6eba90785883e7dc54e39b54dfe8c83223032317228e89cd6eL52-R55) `packages/CodeDesignPlus.Net.EFCore/project.json` - [[4]](diffhunk://#diff-a737bb61aac0431783f70978df30dab7adff4a8b2159db6bf6d5ed5ca0624977L52-R55) `packages/CodeDesignPlus.Net.Event.Sourcing/project.json` - [[5]](diffhunk://#diff-bd73690730f9f40796c25b7590f5e15ab58bd9d78ca4b63f69e544bd70379172L52-R55) and others)

* Updated the `dotnet sonarscanner begin` command to use the hardcoded SonarQube server URL (`http://sonarqube.codedesignplus.com:9000`) directly in all relevant package configurations. (`packages/CodeDesignPlus.Net.EventStore.PubSub/project.json` - [[1]](diffhunk://#diff-8efc54bf37ecc84563178568d6cf6828ad12c4aed94016c85bad8fc85b1355c5L53-R56) `packages/CodeDesignPlus.Net.EventStore/project.json` - [[2]](diffhunk://#diff-f49e0b1a4361cf2722df4fd6af511d936b083f6f66da0283c088385846c48ffaL52-R55) `packages/CodeDesignPlus.Net.Exceptions/project.json` - [[3]](diffhunk://#diff-903940d1f90078acdba043369c7f9a9a1b03c6cb210af98d6970790576bc9db4L50-R53) and others)

These updates aim to streamline the configuration and reduce the complexity of managing dynamic arguments for SonarQube integration.