### PR TITLE
fix: update container configurations to use ComposeVersion V2 and sim…

### DIFF
--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/EventStoreContainer/EventStoreContainer.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/EventStoreContainer/EventStoreContainer.cs
@@ -25,11 +25,12 @@ public class EventStoreContainer : DockerCompose
             RemoveOrphans = true,
             StopOnDispose = true,
             AlternativeServiceName = "eventstore_" + Guid.NewGuid().ToString("N"),
+            ComposeVersion = ComposeVersion.V2,
         };
 
         // Enable port retrieval and set the container name.
         this.EnableGetPort = true;
-        this.ContainerName = $"{dockerCompose.AlternativeServiceName}-eventstore.db";
+        this.ContainerName = $"eventstore.db";
 
         // Create and return the Docker Compose service.
         var compose = new DockerComposeCompositeService(base.DockerHost, dockerCompose);

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/KafkaContainer/KafkaContainer.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/KafkaContainer/KafkaContainer.cs
@@ -38,12 +38,13 @@ public class KafkaContainer : DockerCompose
             {
                 { "KAFKA_PORT" , random.Next(9000, 9999).ToString() },
                 { "KAFKA_HOST_PORT", hostPort.ToString() }
-            }
+            },
+            ComposeVersion = ComposeVersion.V2,
         };
 
         // Disable port retrieval and set the container name.
         this.EnableGetPort = false;
-        this.ContainerName = $"{compose.AlternativeServiceName}-kafka";
+        this.ContainerName = $"kafka";
 
         // Create and return the Docker Compose service.
         return new DockerComposeCompositeService(DockerHost, compose);

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/MongoContainer/MongoContainer.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/MongoContainer/MongoContainer.cs
@@ -18,7 +18,7 @@ public class MongoContainer : DockerCompose
         // Configure the Docker Compose settings.
         var dockerCompose = new DockerComposeConfig
         {
-            ComposeFilePath = new[] { file },
+            ComposeFilePath = [file],
             ForceRecreate = true,
             RemoveOrphans = true,
             StopOnDispose = true,
@@ -26,13 +26,14 @@ public class MongoContainer : DockerCompose
             EnvironmentNameValue = new Dictionary<string, string>
             {
                 { "PORT_CUSTOM", port.ToString() },
-            }
+            },
+            ComposeVersion = ComposeVersion.V2,
         };
 
         // Enable port retrieval and set the internal port and container name.
         this.EnableGetPort = true;
         this.InternalPort = port;
-        this.ContainerName = $"{dockerCompose.AlternativeServiceName}-mongo";
+        this.ContainerName = $"mongo";
 
         // Create and return the Docker Compose service.
         var compose = new DockerComposeCompositeService(base.DockerHost, dockerCompose);

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/MongoContainer/docker-compose.yml
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/MongoContainer/docker-compose.yml
@@ -1,5 +1,7 @@
+version: "3.4"
+
 services:
-  mongo1:
+  mongo:
     image: mongo:latest
     command: ["--replSet", "rs0", "--bind_ip_all", "--port", "${PORT_CUSTOM}"]
     ports:

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/ObservabilityContainer/ObservabilityContainer.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/ObservabilityContainer/ObservabilityContainer.cs
@@ -17,12 +17,15 @@ public class ObservabilityContainer : DockerCompose
         // Configure the Docker Compose settings.
         var dockerCompose = new DockerComposeConfig
         {
-            ComposeFilePath = new[] { file },
+            ComposeFilePath = [file],
             ForceRecreate = true,
             RemoveOrphans = true,
             StopOnDispose = true,
             AlternativeServiceName = "observability_" + Guid.NewGuid().ToString("N"),
+            ComposeVersion = ComposeVersion.V2,
         };
+
+        this.EnableGetPort = false;
 
         // Create and return the Docker Compose service.
         var compose = new DockerComposeCompositeService(base.DockerHost, dockerCompose);

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/OpenTelemetry/OpenTelemetryContainer.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/OpenTelemetry/OpenTelemetryContainer.cs
@@ -17,17 +17,18 @@ public class OpenTelemetryContainer : DockerCompose
         // Configure the Docker Compose settings.
         var dockerCompose = new DockerComposeConfig
         {
-            ComposeFilePath = new[] { file },
+            ComposeFilePath = [file],
             ForceRecreate = true,
             RemoveOrphans = true,
             StopOnDispose = true,
             AlternativeServiceName = "otel_" + Guid.NewGuid().ToString("N"),
+            ComposeVersion = ComposeVersion.V2,
         };
 
         // Enable port retrieval and set the internal port and container name.
         this.EnableGetPort = true;
         this.InternalPort = 4317;
-        this.ContainerName = $"{dockerCompose.AlternativeServiceName}-otel-collector";
+        this.ContainerName = $"otel.collector";
 
         // Create and return the Docker Compose service.
         var compose = new DockerComposeCompositeService(base.DockerHost, dockerCompose);

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/OpenTelemetry/docker-compose.yml
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/OpenTelemetry/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  otel-collector:
+  otel.collector:
     image: otel/opentelemetry-collector
     ports:
       - "0:4317"

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/RabbitMQContainer/RabbitMQContainer.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/RabbitMQContainer/RabbitMQContainer.cs
@@ -22,12 +22,13 @@ public class RabbitMQContainer : DockerCompose
             RemoveOrphans = true,
             StopOnDispose = true,
             AlternativeServiceName = "rabbitmq_" + Guid.NewGuid().ToString("N"),
+            ComposeVersion = ComposeVersion.V2,
         };
 
         // Enable port retrieval and set the internal port and container name.
         this.EnableGetPort = true;
         this.InternalPort = 5672;
-        this.ContainerName = $"{dockerCompose.AlternativeServiceName}-rabbitmq";
+        this.ContainerName = $"rabbitmq";
 
         // Create and return the Docker Compose service.
         var compose = new DockerComposeCompositeService(base.DockerHost, dockerCompose);

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/RedisContainer/RedisContainer.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/RedisContainer/RedisContainer.cs
@@ -78,11 +78,12 @@ public class RedisContainer : DockerCompose
             RemoveOrphans = true,
             StopOnDispose = true,
             AlternativeServiceName = "redis_" + Guid.NewGuid().ToString("N"),
+            ComposeVersion = ComposeVersion.V2,
         };
 
         EnableGetPort = true;
         InternalPort = 6380;
-        ContainerName = $"{dockerCompose.AlternativeServiceName}-redis";
+        ContainerName = $"redis";
 
         var compose = new DockerComposeCompositeService(DockerHost, dockerCompose);
 

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/SqlServer/SqlServerContainer.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/SqlServer/SqlServerContainer.cs
@@ -22,12 +22,13 @@ public class SqlServerContainer : DockerCompose
             RemoveOrphans = true,
             StopOnDispose = true,
             AlternativeServiceName = "sql_" + Guid.NewGuid().ToString("N"),
+            ComposeVersion = ComposeVersion.V2,
         };
 
         // Enable port retrieval and set the internal port and container name.
         this.EnableGetPort = true;
         this.InternalPort = 1433;
-        this.ContainerName = $"{dockerCompose.AlternativeServiceName}-sqlserver";
+        this.ContainerName = $"sqlserver";
 
         // Create and return the Docker Compose service.
         var compose = new DockerComposeCompositeService(base.DockerHost, dockerCompose);

--- a/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/VaultContainer/VaultContainer.cs
+++ b/packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/VaultContainer/VaultContainer.cs
@@ -32,12 +32,13 @@ public class VaultContainer : DockerCompose
             EnvironmentNameValue = new Dictionary<string, string>
             {
                 { "FILE_CREDENTIAL", this.id },
-            }
+            },
+            ComposeVersion = ComposeVersion.V2,
         };
 
         this.EnableGetPort = true;
         this.InternalPort = 8200;
-        this.ContainerName = $"{dockerCompose.AlternativeServiceName}-vault";
+        this.ContainerName = $"vault";
 
         var compose = new DockerComposeCompositeService(base.DockerHost, dockerCompose);
 


### PR DESCRIPTION
This pull request updates multiple container configurations in the `CodeDesignPlus.Net.xUnit` project to align with Docker Compose version 2 and standardize container naming conventions. Additionally, it includes minor syntax updates in the `ComposeFilePath` property and adjusts corresponding `docker-compose.yml` files where necessary.

### Updates to Docker Compose Configuration:

* **Docker Compose Version Update**: All container configurations now specify `ComposeVersion.V2` for compatibility with Docker Compose version 2. (`[[1]](diffhunk://#diff-54dbe0394fa9ad9fbc5249d46961c9d87d85131a09987c470fda96bd22736f29R28-R33)`, `[[2]](diffhunk://#diff-3b73386012dfc7e81786571494d8f38d3fd4eb3936b15e27ebded2197ad4aad7L41-R47)`, `[[3]](diffhunk://#diff-3dfdecbdaa82e0440db0b25beba62a91fd2956f6123e17f075a3677a0edb1cdeL21-R36)`, `[[4]](diffhunk://#diff-552471b40a48dd1861d92de78fdcd3a0c36f04567346346a7b4a58efc23eb366L20-R29)`, `[[5]](diffhunk://#diff-c800a6b566114a86a7d26a03eb2fe9571967f6e2f0400277303a5cb12f505120L20-R31)`, `[[6]](diffhunk://#diff-326e3d6fdec49e49eaaa8a0eba5d43040000b646baf857fdc7a5e2e3378441a2R25-R31)`, `[[7]](diffhunk://#diff-5d94e6e47201c2a703343ab85b1e9d8a7d5d02cf5d0a4c78a2d2205c345b31d5R81-R86)`, `[[8]](diffhunk://#diff-c99ffdabb007b8d28c74d69d54d50d6683af865605a3750974e0dacc8daefc20R25-R31)`, `[[9]](diffhunk://#diff-4baea2a46fe170994d6980318e36e4ffa9be1803e6d3b020a7737850980bc723L35-R41)`)

### Container Naming Standardization:

* **Simplified Container Names**: The `ContainerName` property for all containers has been updated to use a straightforward naming convention (e.g., `eventstore.db`, `mongo`, `rabbitmq`, etc.), removing dynamically generated names based on `AlternativeServiceName`. (`[[1]](diffhunk://#diff-54dbe0394fa9ad9fbc5249d46961c9d87d85131a09987c470fda96bd22736f29R28-R33)`, `[[2]](diffhunk://#diff-3b73386012dfc7e81786571494d8f38d3fd4eb3936b15e27ebded2197ad4aad7L41-R47)`, `[[3]](diffhunk://#diff-3dfdecbdaa82e0440db0b25beba62a91fd2956f6123e17f075a3677a0edb1cdeL21-R36)`, `[[4]](diffhunk://#diff-552471b40a48dd1861d92de78fdcd3a0c36f04567346346a7b4a58efc23eb366L20-R29)`, `[[5]](diffhunk://#diff-c800a6b566114a86a7d26a03eb2fe9571967f6e2f0400277303a5cb12f505120L20-R31)`, `[[6]](diffhunk://#diff-326e3d6fdec49e49eaaa8a0eba5d43040000b646baf857fdc7a5e2e3378441a2R25-R31)`, `[[7]](diffhunk://#diff-5d94e6e47201c2a703343ab85b1e9d8a7d5d02cf5d0a4c78a2d2205c345b31d5R81-R86)`, `[[8]](diffhunk://#diff-c99ffdabb007b8d28c74d69d54d50d6683af865605a3750974e0dacc8daefc20R25-R31)`, `[[9]](diffhunk://#diff-4baea2a46fe170994d6980318e36e4ffa9be1803e6d3b020a7737850980bc723L35-R41)`)

### Syntax and Configuration Adjustments:

* **Syntax Update for `ComposeFilePath`**: The `ComposeFilePath` property has been updated to use square brackets (`[file]`) instead of `new[] { file }` for improved readability. (`[[1]](diffhunk://#diff-3dfdecbdaa82e0440db0b25beba62a91fd2956f6123e17f075a3677a0edb1cdeL21-R36)`, `[[2]](diffhunk://#diff-552471b40a48dd1861d92de78fdcd3a0c36f04567346346a7b4a58efc23eb366L20-R29)`, `[[3]](diffhunk://#diff-c800a6b566114a86a7d26a03eb2fe9571967f6e2f0400277303a5cb12f505120L20-R31)`)
* **`docker-compose.yml` Updates**:
  - The `mongo` service name in `MongoContainer/docker-compose.yml` has been updated to match the new naming convention. (`[packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/MongoContainer/docker-compose.ymlR1-R4](diffhunk://#diff-d37669047b14cc3ee2226f578ec2f3ddcf4108c1051119bdbe5ef2f2bd8b801eR1-R4)`)
  - The `otel.collector` service name in `OpenTelemetry/docker-compose.yml` has been updated accordingly. (`[packages/CodeDesignPlus.Net.xUnit/src/CodeDesignPlus.Net.xUnit/Containers/OpenTelemetry/docker-compose.ymlL2-R2](diffhunk://#diff-9faa94ffa8258265d30f54488e269c8b8ab492de97290e72680b48138727503cL2-R2)`)