### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Services/Rbac.cs
+++ b/packages/CodeDesignPlus.Net.Security/src/CodeDesignPlus.Net.Security/Services/Rbac.cs
@@ -73,7 +73,8 @@ public class Rbac : IRbac
 
         var isAuthorized = resources.Any(x => x.Controller == controller && x.Action == action && x.Method == httpMethod && roles.Contains(x.Role));
 
-        this.logger.LogDebug("Role '{Role}' is {Authorized} to access the resource '{Controller}/{Action}' with the method '{HttpVerb}'", string.Join(",", roles), isAuthorized ? "authorized" : "not authorized", controller, action, httpVerb);
+        var sanitizedHttpVerb = httpVerb.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        this.logger.LogDebug("Role '{Role}' is {Authorized} to access the resource '{Controller}/{Action}' with the method '{HttpVerb}'", string.Join(",", roles), isAuthorized ? "authorized" : "not authorized", controller, action, sanitizedHttpVerb);
 
         return Task.FromResult(isAuthorized);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/codedesignplus/CodeDesignPlus.Net.Sdk/security/code-scanning/1](https://github.com/codedesignplus/CodeDesignPlus.Net.Sdk/security/code-scanning/1)

The best way to fix the issue is to sanitize the `httpVerb` before logging it. Given that the log entries are written as plain text, we should remove any newline characters or other potentially harmful characters from the `httpVerb` string. This can be achieved using `string.Replace` or a regular expression to filter out disallowed characters.

Specifically, the fix involves:
1. Sanitizing the `httpVerb` immediately before it is passed to the logger in the `IsAuthorizedAsync` method.
2. Ensuring that the sanitization process removes any newline or control characters that could be used to forge log entries.

Modifications will be made to the `IsAuthorizedAsync` method in the `Rbac` class.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
